### PR TITLE
OSSM-4505 Add script to run integration test againt OCP cluster

### DIFF
--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -17,6 +17,7 @@
 # This script is used to run the integration tests on OpenShift.
 # Usage: ./integ-suite-ocp.sh TEST_SUITE SKIP_TESTS, example: /prow/integ-suite-ocp.sh telemetry "TestClientTracing|TestServerTracing"
 # TEST_SUITE: The test suite to run. Default is "pilot". Available options are "pilot", "security", "telemetry", "helm".
+# TODO: Use the same arguments as integ-suite.kind.sh uses
 
 WD=$(dirname "$0")
 ROOT=$(dirname "$WD")
@@ -35,7 +36,7 @@ set -u
 set -x
 
 # shellcheck source=common/scripts/kind_provisioner.sh
-source "${ROOT}/common/scripts/ocp_setup.sh"
+source "${ROOT}/prow/setup/ocp_setup.sh"
 
 build_images() {
     # Build just the images needed for tests
@@ -66,6 +67,8 @@ echo "Running integration tests"
 HUB="image-registry.openshift-image-registry.svc:5000/${NAMESPACE}"
 
 # Build the base command and store it in a variable.
+# TODO: execute the test by running make target. Do we need first to add a skip flag to the make target to be able to skip failing test on OCP
+# All the flags are needed to run the integration tests on OCP
 base_cmd="go test -p 1 -v -count=1 -tags=integ -vet=off -timeout 60m ./tests/integration/${TEST_SUITE}/... \
 --istio.test.ci \
 --istio.test.pullpolicy=IfNotPresent \

--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Copyright 2019 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used to run the integration tests on OpenShift.
+# Usage: ./integ-suite-ocp.sh TEST_SUITE SKIP_TESTS, example: /prow/integ-suite-ocp.sh telemetry "TestClientTracing|TestServerTracing"
+# TEST_SUITE: The test suite to run. Default is "pilot". Available options are "pilot", "security", "telemetry", "helm".
+
+WD=$(dirname "$0")
+ROOT=$(dirname "$WD")
+WD=$(cd "$WD"; pwd)
+TIMEOUT=300
+export NAMESPACE="${NAMESPACE:-"istio-system"}"
+export TAG="${TAG:-"istio-testing"}"
+SKIP_TESTS="${2:-""}"
+TEST_SUITE="${1:-"pilot"}"
+
+# Exit immediately for non zero status
+set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
+
+# shellcheck source=common/scripts/kind_provisioner.sh
+source "${ROOT}/common/scripts/ocp_setup.sh"
+
+build_images() {
+    # Build just the images needed for tests
+    targets="docker.pilot docker.proxyv2 docker.install-cni "
+
+    # Integration tests are always running on local architecture (no cross compiling), so find out what that is.
+    arch="linux/amd64"
+    if [[ "$(uname -m)" == "aarch64" ]]; then
+        arch="linux/arm64"
+    fi
+
+    # use ubuntu:jammy to test vms by default
+    nonDistrolessTargets="docker.app docker.app_sidecar_ubuntu_jammy docker.ext-authz "
+
+    DOCKER_ARCHITECTURES="${arch}"  DOCKER_BUILD_VARIANTS="${VARIANT:-default}" DOCKER_TARGETS="${targets} ${nonDistrolessTargets}" make dockerx.pushx
+}
+
+# Setup the internal registry for ocp cluster
+setup_internal_registry
+
+# Build and push the images to the internal registry
+build_images
+
+# Run the integration tests
+echo "Running integration tests"
+
+# Set the HUB to the internal registry svc URL to avoid the need to authenticate to pull images
+HUB="image-registry.openshift-image-registry.svc:5000/${NAMESPACE}"
+
+# Build the base command and store it in a variable.
+base_cmd="go test -p 1 -v -count=1 -tags=integ -vet=off -timeout 60m ./tests/integration/${TEST_SUITE}/... \
+--istio.test.ci \
+--istio.test.pullpolicy=IfNotPresent \
+--istio.test.work_dir=result \
+--istio.test.skipTProxy=true \
+--istio.test.skipVM=true \
+--istio.test.kube.helm.values=profile=openshift,global.platform=openshift \
+--istio.test.istio.enableCNI=true \
+--istio.test.hub=\"${HUB}\" \
+--istio.test.tag=\"${TAG}\""
+
+# Check if SKIP_TESTS is non-empty and append the -skip flag if it is.
+if [ -n "${SKIP_TESTS}" ]; then
+  base_cmd+=" -skip '${SKIP_TESTS}'"
+fi
+
+# Execute the command.
+eval "$base_cmd"

--- a/prow/setup/ocp_setup.sh
+++ b/prow/setup/ocp_setup.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# WARNING: DO NOT EDIT, THIS FILE IS PROBABLY A COPY
+#
+# The original version of this file is located in the https://github.com/istio/common-files repo.
+# If you're looking at this file in a different repo and want to make a change, please go to the
+# common-files repo, make the change there and check it in. Then come back to this repo and run
+# "make update-common".
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+
+# The purpose of this file is to unify ocp setup in both istio/istio and istio-ecosystem/sail-operator.
+# repos to avoid code duplication. This is needed to setup the OCP environment for the tests.
+
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+TIMEOUT=300
+export NAMESPACE="${NAMESPACE:-"istio-system"}"
+
+function setup_internal_registry() {
+  # Validate that the internal registry is running in the OCP Cluster, configure the variable to be used in the make target. 
+  # If there is no internal registry, the test can't be executed targeting to the internal registry
+
+  # Check if the registry pods are running
+  oc get pods -n openshift-image-registry --no-headers | grep -v "Running\|Completed" && echo "It looks like the OCP image registry is not deployed or Running. This tests scenario requires it. Aborting." && exit 1
+
+  # Check if default route already exist
+  if [ -z "$(oc get route default-route -n openshift-image-registry -o name)" ]; then
+    echo "Route default-route does not exist, patching DefaultRoute to true on Image Registry."
+    oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
+  
+    timeout --foreground -v -s SIGHUP -k ${TIMEOUT} ${TIMEOUT} bash --verbose -c \
+      "until oc get route default-route -n openshift-image-registry &> /dev/null; do sleep 5; done && echo 'The 'default-route' has been created.'"
+  fi
+
+  # Get the registry route
+  URL=$(oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}')
+  # Hub will be equal to the route url/project-name(NameSpace) 
+  export HUB="${URL}/${NAMESPACE}"
+  echo "Internal registry URL: ${HUB}"
+
+  # Create namespace from where the image are going to be pushed
+  # This is needed because in the internal registry the images are stored in the namespace.
+  # If the namespace already exist, it will not fail
+  oc create namespace "${NAMESPACE}" || true
+
+  deploy_rolebinding
+
+  # Login to the internal registry when running on CRC (Only for local development)
+  # Take into count that you will need to add before the registry URL as Insecure registry in "/etc/docker/daemon.json"
+  if [[ ${URL} == *".apps-crc.testing"* ]]; then
+    echo "Executing Docker login to the internal registry"
+    if ! oc whoami -t | docker login -u "$(oc whoami)" --password-stdin "${URL}"; then
+      echo "***** Error: Failed to log in to Docker registry."
+      echo "***** Check the error and if is related to 'tls: failed to verify certificate' please add the registry URL as Insecure registry in '/etc/docker/daemon.json'"
+      exit 1
+    fi
+  fi
+}
+
+function deploy_rolebinding() {
+    # Adding roles to avoid the need to be authenticated to push images to the internal registry 
+    # and pull them later in the any namespace
+      echo '
+kind: List
+apiVersion: v1
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: image-puller
+    namespace: '"$NAMESPACE"'
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:image-puller
+  subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: system:unauthenticated
+  - kind: Group
+    name: system:serviceaccounts
+    apiGroup: rbac.authorization.k8s.io
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: image-pusher
+    namespace: '"$NAMESPACE"'
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:image-builder
+  subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: system:unauthenticated
+' | oc apply -f -
+}


### PR DESCRIPTION
This is part of https://issues.redhat.com/browse/OSSM-4505, the idea is to use the script in prow jobs definitions to be able to start running tests over OCP clusters to test all the changes upstream.

How to use it in prow:
This will be used by calling the script  + suiteName + SkippedTest(If apply), for example: `/prow/integ-suite-ocp.sh telemetry "TestClientTracing|TestServerTracing"`

Available suites are: "pilot", "security", "telemetry", "helm". More information in the Epic: https://issues.redhat.com/browse/OSSM-4504
