### PR TITLE
OSSM-6313 Update getAddressTimeout in our fork

### DIFF
--- a/pkg/test/framework/components/istio/ingress.go
+++ b/pkg/test/framework/components/istio/ingress.go
@@ -47,7 +47,7 @@ const (
 )
 
 var (
-	getAddressTimeout = retry.Timeout(3 * time.Minute)
+	getAddressTimeout = retry.Timeout(5 * time.Minute)
 	getAddressDelay   = retry.BackoffDelay(500 * time.Millisecond)
 
 	_ ingress.Instance = &ingressImpl{}


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSSM-6313

We need to increase getAddressTimeout in our fork to be able to run properly the integration test because the load balancer services take more time than expected to be ready. Without this we can get flaky result in the execution of the prow jobs that are running the integration test