### PR TITLE
Fix ocp running test script affected by upstream test

### DIFF
--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -49,7 +49,7 @@ build_images() {
     fi
 
     # use ubuntu:jammy to test vms by default
-    nonDistrolessTargets="docker.app docker.app_sidecar_ubuntu_jammy docker.ext-authz "
+    nonDistrolessTargets="docker.app docker.app_sidecar_ubuntu_noble docker.ext-authz "
 
     DOCKER_ARCHITECTURES="${arch}"  DOCKER_BUILD_VARIANTS="${VARIANT:-default}" DOCKER_TARGETS="${targets} ${nonDistrolessTargets}" make dockerx.pushx
 }

--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -48,7 +48,7 @@ build_images() {
         arch="linux/arm64"
     fi
 
-    # use ubuntu:jammy to test vms by default
+    # use ubuntu:noble to test vms by default
     nonDistrolessTargets="docker.app docker.app_sidecar_ubuntu_noble docker.ext-authz "
 
     DOCKER_ARCHITECTURES="${arch}"  DOCKER_BUILD_VARIANTS="${VARIANT:-default}" DOCKER_TARGETS="${targets} ${nonDistrolessTargets}" make dockerx.pushx


### PR DESCRIPTION
The commit [8f9f58bc073968436e7239bd85ac9add5d1d6f7d upstream](https://github.com/openshift-service-mesh/istio/pull/16/commits/8f9f58bc073968436e7239bd85ac9add5d1d6f7d) change the base image. We need to update the information in our custom script to run on ocp the integration test

