### PR TITLE
Adding unset var when helm test are executed DOCKER_CONFIG

### DIFF
--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -43,6 +43,8 @@ set -u
 # Print commands
 set -x
 
+set -o pipefail
+
 # shellcheck source=common/scripts/kind_provisioner.sh
 source "${ROOT}/prow/setup/ocp_setup.sh"
 
@@ -122,6 +124,11 @@ if [ "${TEST_OUTPUT_FORMAT}" == "junit" ]; then
     echo "A junit report file will be generated"
     setup_junit_report
     base_cmd+=" 2>&1 | tee >(${JUNIT_REPORT} > ${ARTIFACTS_DIR}/junit/junit.xml)"
+fi
+
+# unset DOCKER_CONFIG var to avoid credentials error when helm test is running
+if [ "${TEST_SUITE}" == "helm" ]; then
+    unset DOCKER_CONFIG
 fi
 
 # Execute the command.


### PR DESCRIPTION
Executing in prow the helm test suite we got errors in the setup of the upgrade test related to credentials `getting credentials - err: exit status 1, out: `You do not currently have an active account selected. See https://cloud.google.com/sdk/docs/authorizing for more information.`

A workaround to avoid this error is to unset the `DOCKER_CONFIG` var when the helm test is being executed