### PR TITLE
OSSM-6600 Avoid failures to be hidden on integration test

### DIFF
--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -116,12 +116,11 @@ if [ "${TEST_OUTPUT_FORMAT}" == "junit" ]; then
     echo "A junit report file will be generated"
     setup_junit_report
     "${base_cmd[@]}" 2>&1 | tee >( "${JUNIT_REPORT}" > "${ARTIFACTS_DIR}/junit/junit.xml" )
+    test_status=${PIPESTATUS[0]}
 else
     "${base_cmd[@]}"
+    test_status=$?
 fi
 
-
-# For debugging purposes, print the conten of the junit folder
-echo "********* Junit report and artifacts"
-ls -l "${JUNIT_REPORT_DIR}"
-ls -l "${ARTIFACTS_DIR}"
+# Exit with the status of the test command
+exit $test_status

--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -117,7 +117,12 @@ fi
 if [ "${TEST_OUTPUT_FORMAT}" == "junit" ]; then
     echo "A junit report file will be generated"
     setup_junit_report
-    "${base_cmd[@]}" 2>&1 | tee >( /usr/bin/go-junit-report > "${ARTIFACTS_DIR}/junit/junit.xml" )
+    "${base_cmd[@]}" 2>&1 | tee >( "${JUNIT_REPORT}" > "${ARTIFACTS_DIR}/junit/junit.xml" )
 else
     "${base_cmd[@]}"
 fi
+
+
+# For debugging purposes, print the conten of the junit folder
+ls -l "${JUNIT_REPORT_DIR}"
+ls -l "${ARTIFACTS_DIR}"

--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -117,7 +117,7 @@ fi
 if [ "${TEST_OUTPUT_FORMAT}" == "junit" ]; then
     echo "A junit report file will be generated"
     setup_junit_report
-    "${base_cmd[@]}" 2>&1 | tee >( ${JUNIT_REPORT} > ${ARTIFACTS_DIR}/junit/junit.xml )
+    "${base_cmd[@]}" 2>&1 | tee >( /usr/bin/go-junit-report > "${ARTIFACTS_DIR}/junit/junit.xml" )
 else
     "${base_cmd[@]}"
 fi

--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -43,8 +43,6 @@ set -u
 # Print commands
 set -x
 
-set -o pipefail
-
 # shellcheck source=common/scripts/kind_provisioner.sh
 source "${ROOT}/prow/setup/ocp_setup.sh"
 
@@ -124,5 +122,6 @@ fi
 
 
 # For debugging purposes, print the conten of the junit folder
+echo "********* Junit report and artifacts"
 ls -l "${JUNIT_REPORT_DIR}"
 ls -l "${ARTIFACTS_DIR}"


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSSM-6600

We need to capture the exit code when the go test command is being executed in our CI, it seems to be that eval among tee is hiding the exit code when is running in our ci