### PR TITLE
Integration test run: delete profile set to openshift after upstream changes in helm api

### DIFF
--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -100,7 +100,7 @@ base_cmd=("go" "test" "-p" "1" "-v" "-count=1" "-tags=integ" "-vet=off" "-timeou
           "--istio.test.work_dir=${ARTIFACTS_DIR}"
           "--istio.test.skipTProxy=true"
           "--istio.test.skipVM=true"
-          "--istio.test.kube.helm.values=profile=openshift,global.platform=openshift"
+          "--istio.test.kube.helm.values=global.platform=openshift"
           "--istio.test.istio.enableCNI=true"
           "--istio.test.hub=${HUB}"
           "--istio.test.tag=${TAG}"


### PR DESCRIPTION
After the merge of this [PR](https://github.com/istio/istio/pull/52981) upstream there is no need to set  `profile=openshift` in the `istio.test.kube.helm.values`