### PR TITLE
Add on ocp setup the build of ztunnel image

### DIFF
--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -57,7 +57,7 @@ build_images() {
     fi
 
     # use ubuntu:noble to test vms by default
-    nonDistrolessTargets="docker.app docker.app_sidecar_ubuntu_noble docker.ext-authz "
+    nonDistrolessTargets="docker.app docker.app_sidecar_ubuntu_noble docker.ext-authz docker.ztunnel "
 
     if [[ "${VARIANT:-default}" == "distroless" ]]; then
         echo "Building distroless images"


### PR DESCRIPTION
Adding the ztunnel image build and push to the local registry will allow us to run the ambient related test on OCP.

This PR needs to be merged before merging the release repo change to be tested in the release repository. Another chicken-egg issue: We will need to override the helm test job here to be able to merge it