### PR TITLE
Add retry timeouts delay for AWS LB

### DIFF
--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -4242,7 +4242,7 @@ spec:
 			//TODO: Fix it properly as recommended https://github.com/istio/istio/pull/54244#pullrequestreview-2489497585
 			Retry: echo.Retry{
 				Options: []retry.Option{retry.Timeout(2 * time.Minute)},
-			}
+			},
 		},
 		setupOpts: setHostHeader,
 	})

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -4204,6 +4204,11 @@ spec:
 				Headers: headersWithToken2,
 			},
 			Check: check.Status(http.StatusOK),
+			// Retry with a longer duration until the AWS LB is available
+			//TODO: Fix it properly as recommended https://github.com/istio/istio/pull/54244#pullrequestreview-2489497585
+			Retry: echo.Retry{
+				Options: []retry.Option{retry.Timeout(2 * time.Minute)},
+			},
 		},
 		setupOpts: setHostHeader,
 	})
@@ -4233,6 +4238,11 @@ spec:
 				Headers: headersWithToken2,
 			},
 			Check: check.Status(http.StatusOK),
+			// Retry with a longer duration until the AWS LB is available
+			//TODO: Fix it properly as recommended https://github.com/istio/istio/pull/54244#pullrequestreview-2489497585
+			Retry: echo.Retry{
+				Options: []retry.Option{retry.Timeout(2 * time.Minute)},
+			}
 		},
 		setupOpts: setHostHeader,
 	})


### PR DESCRIPTION
**Please provide a description of this PR:**

Because the AWS loadbalancer takes time to be available, the `TestTraffic/jwt-claim-route/matched_with_nested_claim_using_claim_to_header` and `TestTraffic/jwt-claim-route/matched_with_nested_claim_and_single_claim_using_claim_to_header` are [failing](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-service-mesh_istio/210/pull-ci-openshift-service-mesh-istio-master-istio-integration-pilot/1864916823753887744#1:build-log.txt%3A1928).

Setting the retry timeout delay for these tests should fix the issue.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
