### PR TITLE
Fix go linter errors

### DIFF
--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -199,7 +199,7 @@ debug and diagnose their Istio mesh.
 	experimentalCmd.AddCommand(precheck.Cmd(ctx))
 	experimentalCmd.AddCommand(proxyconfig.StatsConfigCmd(ctx))
 	experimentalCmd.AddCommand(checkinject.Cmd(ctx))
-	//TODO: revisit once ambient mode is supported in Sail Operator.
+	// TODO: revisit once ambient mode is supported in Sail Operator.
 	rootCmd.AddCommand(unsupportedCmd(waypoint.Cmd(ctx), "none"))
 	rootCmd.AddCommand(unsupportedCmd(ztunnelconfig.ZtunnelConfig(ctx), "none"))
 
@@ -290,6 +290,7 @@ func ConfigureLogging(_ *cobra.Command, _ []string) error {
 // Other alternative
 // for graduatedCmd see https://github.com/istio/istio/pull/26408
 // for softGraduatedCmd see https://github.com/istio/istio/pull/26563
+// nolint: unused
 func seeExperimentalCmd(name string) *cobra.Command {
 	msg := fmt.Sprintf("(%s is experimental. Use `istioctl experimental %s`)", name, name)
 	return &cobra.Command{

--- a/istioctl/pkg/multicluster/remote_secret.go
+++ b/istioctl/pkg/multicluster/remote_secret.go
@@ -384,7 +384,7 @@ func legacyGetServiceAccountSecret(
 
 func getOrCreateServiceAccount(client kube.CLIClient, opt RemoteSecretOptions) (*v1.ServiceAccount, error) {
 	if opt.CreateServiceAccount {
-		return nil, fmt.Errorf("'--create-service-account=false' should be set when using OpenShift Service Mesh Operator.")
+		return nil, fmt.Errorf("'--create-service-account=false' should be set when using OpenShift Service Mesh Operator")
 	}
 
 	if sa, err := client.Kube().CoreV1().ServiceAccounts(opt.Namespace).Get(

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -4205,7 +4205,7 @@ spec:
 			},
 			Check: check.Status(http.StatusOK),
 			// Retry with a longer duration until the AWS LB is available
-			//TODO: Fix it properly as recommended https://github.com/istio/istio/pull/54244#pullrequestreview-2489497585
+			// TODO: Fix it properly as recommended https://github.com/istio/istio/pull/54244#pullrequestreview-2489497585
 			Retry: echo.Retry{
 				Options: []retry.Option{retry.Timeout(2 * time.Minute)},
 			},
@@ -4239,7 +4239,7 @@ spec:
 			},
 			Check: check.Status(http.StatusOK),
 			// Retry with a longer duration until the AWS LB is available
-			//TODO: Fix it properly as recommended https://github.com/istio/istio/pull/54244#pullrequestreview-2489497585
+			// TODO: Fix it properly as recommended https://github.com/istio/istio/pull/54244#pullrequestreview-2489497585
 			Retry: echo.Retry{
 				Options: []retry.Option{retry.Timeout(2 * time.Minute)},
 			},


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixing the golang linter errors that happened in the `release-1.24` [branch](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-service-mesh_istio/228/pull-ci-openshift-service-mesh-istio-release-1.24-lint/1866513970542678016)

> [!NOTE]
> We may need to enable the lint job in the `master` branch to avoid this kind of case

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
