### PR TITLE
Enable istioctl related ambient commands

### DIFF
--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -199,9 +199,8 @@ debug and diagnose their Istio mesh.
 	experimentalCmd.AddCommand(precheck.Cmd(ctx))
 	experimentalCmd.AddCommand(proxyconfig.StatsConfigCmd(ctx))
 	experimentalCmd.AddCommand(checkinject.Cmd(ctx))
-	// TODO: revisit once ambient mode is supported in Sail Operator.
-	rootCmd.AddCommand(unsupportedCmd(waypoint.Cmd(ctx), "none"))
-	rootCmd.AddCommand(unsupportedCmd(ztunnelconfig.ZtunnelConfig(ctx), "none"))
+	rootCmd.AddCommand(waypoint.Cmd(ctx))
+	rootCmd.AddCommand(ztunnelconfig.ZtunnelConfig(ctx))
 
 	analyzeCmd := analyze.Analyze(ctx)
 	hideInheritedFlags(analyzeCmd, cli.FlagIstioNamespace)


### PR DESCRIPTION
**Please provide a description of this PR:**

Re-enable istioctl related ambient commands `waypoint` and `ztunnel-config`.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
