### PR TITLE
Adding SKIP_SETUP SKIP_TEST_RUN and DEPLOY_METALLB to ocp test run script

### DIFF
--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -70,26 +70,30 @@ build_images() {
     fi
 }
 
-# Skip the setup if the flag is set
-if [ "${SKIP_SETUP}" == "false" ]; then
-    # Check if artifact dir exist and if not create it in the current directory
-    ARTIFACTS_DIR="${ARTIFACT_DIR:-"${WD}/artifacts"}"
-    mkdir -p "${ARTIFACTS_DIR}/junit"
-    JUNIT_REPORT_DIR="${ARTIFACTS_DIR}/junit"
+# Define the artifacts directory
+ARTIFACTS_DIR="${ARTIFACT_DIR:-"${WD}/artifacts"}"
+JUNIT_REPORT_DIR="${ARTIFACTS_DIR}/junit"
 
-    # Setup the internal registry for ocp cluster
-    setup_internal_registry
-    
-    # Build and push the images to the internal registry
-    build_images
-else 
-    echo "Skipping the setup"
-fi
-
-# Install the MetalLB if the flag is set
+# Install MetalLB if the flag is set
 if [ "${INSTALL_METALLB}" == "true" ]; then
     echo "Installing MetalLB"
     deployMetalLB
+
+# Run the setup only if MetalLB is not being installed and setup is not skipped
+elif [ "${INSTALL_METALLB}" != "true" ] && [ "${SKIP_SETUP}" != "true" ]; then
+    echo "Running full setup..."
+
+    # Ensure artifacts directory exists
+    mkdir -p "${JUNIT_REPORT_DIR}"
+
+    # Setup the internal registry for the OCP cluster
+    setup_internal_registry
+
+    # Build and push the images to the internal registry
+    build_images
+
+else
+    echo "Skipping the setup"
 fi
 
 # Check if the test run should be skipped


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR aims to add a way to simply install a MetalLB operator with a MetalLB controller and his IP Address pool. This will avoid issues while we are running the istio integration test against the cluster created by the UPI job (Load balancer issue).

On this PR, I add:

- SKIP_SETUP to avoid running the setup for OCP clusters. On downstream testing, we do not need to set up the cluster because we already have the operator installed, and we do not need to build the images
- INSTALL_METALLB, to run a specific function that installs the operator from the catalog and sets the IP Address pool by using the IP of the worker nodes
- SKIP_TEST_RUN, to avoid running the test from the script. This is only a workaround because @ctartici is working on a standardized way to execute the integration test against upstream and downstream Sail Operator 


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
