### PR TITLE
gateway-api: allow disabling manual deployments

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -2351,7 +2351,12 @@ func reportUnmanagedGatewayStatus(obj config.Config) {
 // NamedAddress - Service has no concept of named address. For cloud's that have named addresses they can be configured by annotations,
 //
 //	which users can add to the Gateway.
+//
+// If manual deployments are disabled, IsManaged() always returns true.
 func IsManaged(gw *k8s.GatewaySpec) bool {
+	if !features.EnableGatewayAPIManualDeployment {
+		return true
+	}
 	if len(gw.Addresses) == 0 {
 		return true
 	}

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -1367,12 +1367,13 @@ func BenchmarkBuildHTTPVirtualServices(b *testing.B) {
 
 func TestExtractGatewayServices(t *testing.T) {
 	tests := []struct {
-		name            string
-		r               GatewayResources
-		kgw             *k8s.GatewaySpec
-		obj             config.Config
-		gatewayServices []string
-		err             *ConfigError
+		name                   string
+		r                      GatewayResources
+		kgw                    *k8s.GatewaySpec
+		obj                    config.Config
+		gatewayServices        []string
+		err                    *ConfigError
+		enableManualDeployment bool
 	}{
 		{
 			name: "managed gateway",
@@ -1386,7 +1387,8 @@ func TestExtractGatewayServices(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			gatewayServices: []string{"foo-istio.default.svc.cluster.local"},
+			gatewayServices:        []string{"foo-istio.default.svc.cluster.local"},
+			enableManualDeployment: true,
 		},
 		{
 			name: "managed gateway with name overridden",
@@ -1403,7 +1405,8 @@ func TestExtractGatewayServices(t *testing.T) {
 					},
 				},
 			},
-			gatewayServices: []string{"bar.default.svc.cluster.local"},
+			gatewayServices:        []string{"bar.default.svc.cluster.local"},
+			enableManualDeployment: true,
 		},
 		{
 			name: "unmanaged gateway",
@@ -1441,10 +1444,46 @@ func TestExtractGatewayServices(t *testing.T) {
 				Reason:  InvalidAddress,
 				Message: "only Hostname is supported, ignoring [1.2.3.4]",
 			},
+			enableManualDeployment: true,
+		},
+		{
+			name: "manual deployment disabled",
+			r:    GatewayResources{Domain: "domain"},
+			kgw: &k8s.GatewaySpec{
+				GatewayClassName: "istio",
+				Addresses: []k8s.GatewayAddress{
+					{
+						Value: "abc",
+					},
+					{
+						Type: func() *k8s.AddressType {
+							t := k8s.HostnameAddressType
+							return &t
+						}(),
+						Value: "example.com",
+					},
+					{
+						Type: func() *k8s.AddressType {
+							t := k8s.IPAddressType
+							return &t
+						}(),
+						Value: "1.2.3.4",
+					},
+				},
+			},
+			obj: config.Config{
+				Meta: config.Meta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+			},
+			gatewayServices:        []string{"foo-istio.default.svc.domain"},
+			enableManualDeployment: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			test.SetForTest(t, &features.EnableGatewayAPIManualDeployment, tt.enableManualDeployment)
 			gatewayServices, err := extractGatewayServices(tt.r, tt.kgw, tt.obj, classInfo{})
 			assert.Equal(t, gatewayServices, tt.gatewayServices)
 			assert.Equal(t, err, tt.err)

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -242,6 +242,9 @@ var (
 
 	PreferDestinationRulesTLSForExternalServices = env.Register("PREFER_DESTINATIONRULE_TLS_FOR_EXTERNAL_SERVICES", true,
 		"If true, external services will prefer the TLS settings from DestinationRules over the metadata TLS settings.").Get()
+
+	EnableGatewayAPIManualDeployment = env.Register("ENABLE_GATEWAY_API_MANUAL_DEPLOYMENT", true,
+		"If true, allows users to bind Gateway API resources to existing gateway deployments.").Get()
 )
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/releasenotes/notes/gw-manual-deployment.yaml
+++ b/releasenotes/notes/gw-manual-deployment.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+- |
+  **Added** an environment variable `ENABLE_GATEWAY_API_MANUAL_DEPLOYMENT` to istiod that, if set to `false`, will disable the attachment of Gateway API resources to existing gateway deployments. The default setting is `true` to not change existing behavior.


### PR DESCRIPTION
When unmanaged Gateways were introduced in Istio, most gateway deployments were still done with helm charts. We have since introduced Gateway Injection and automatic deployments have come a long way and can be customized by changing the template. Additionally, there is discussion around adding further customization options in #46594.

This PR adds an option to disable manual deployments. The default will still be to enable them, but this gives mesh admins a way to enforce how Gateway API resources are reconciled and how gateways are deployed in the cluster.
