### PR TITLE
Update some examples to use quay.io/sail-dev instead of docker

### DIFF
--- a/samples/bookinfo/platform/kube/bookinfo-db.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-db.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
       - name: mongodb 
-        image: docker.io/istio/examples-bookinfo-mongodb:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-mongodb:1.20.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 27017

--- a/samples/bookinfo/platform/kube/bookinfo-details-dualstack.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details-dualstack.yaml
@@ -52,7 +52,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: docker.io/istio/examples-bookinfo-details-v1:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-details-v1:1.20.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: docker.io/istio/examples-bookinfo-details-v2:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-details-v2:1.20.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-details.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details.yaml
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: docker.io/istio/examples-bookinfo-details-v1:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-details-v1:1.20.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-dualstack.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-dualstack.yaml
@@ -74,7 +74,7 @@ spec:
       serviceAccountName: bookinfo-details
       containers:
       - name: details
-        image: docker.io/istio/examples-bookinfo-details-v1:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-details-v1:1.20.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -127,7 +127,7 @@ spec:
       serviceAccountName: bookinfo-ratings
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v1:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-ratings-v1:1.20.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -180,7 +180,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v1:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-reviews-v1:1.20.2
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -220,7 +220,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v2:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-reviews-v2:1.20.2
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -260,7 +260,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v3:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-reviews-v3:1.20.2
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -330,7 +330,7 @@ spec:
       serviceAccountName: bookinfo-productpage
       containers:
       - name: productpage
-        image: docker.io/istio/examples-bookinfo-productpage-v1:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-productpage-v1:1.20.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
@@ -59,7 +59,7 @@ spec:
     spec:
       containers:
       - name: mysqldb
-        image: docker.io/istio/examples-bookinfo-mysqldb:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-mysqldb:1.20.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3306

--- a/samples/bookinfo/platform/kube/bookinfo-psa.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-psa.yaml
@@ -64,7 +64,7 @@ spec:
       serviceAccountName: bookinfo-details
       containers:
       - name: details
-        image: docker.io/istio/examples-bookinfo-details-v1:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-details-v1:1.20.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -121,7 +121,7 @@ spec:
       serviceAccountName: bookinfo-ratings
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v1:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-ratings-v1:1.20.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -178,7 +178,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v1:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-reviews-v1:1.20.2
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -224,7 +224,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v2:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-reviews-v2:1.20.2
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -270,7 +270,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v3:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-reviews-v3:1.20.2
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -344,7 +344,7 @@ spec:
       serviceAccountName: bookinfo-productpage
       containers:
       - name: productpage
-        image: docker.io/istio/examples-bookinfo-productpage-v1:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-productpage-v1:1.20.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-dualstack.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-dualstack.yaml
@@ -52,7 +52,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v1:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-ratings-v1:1.20.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v2:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-ratings-v2:1.20.2
         imagePullPolicy: IfNotPresent
         env:
           # This assumes you registered your mysql vm as

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v2:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-ratings-v2:1.20.2
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: bookinfo-ratings-v2
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v2:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-ratings-v2:1.20.2
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v1:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-ratings-v1:1.20.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v2:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-reviews-v2:1.20.2
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR

--- a/samples/bookinfo/platform/kube/bookinfo.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo.yaml
@@ -72,7 +72,7 @@ spec:
       serviceAccountName: bookinfo-details
       containers:
       - name: details
-        image: docker.io/istio/examples-bookinfo-details-v1:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-details-v1:1.20.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -123,7 +123,7 @@ spec:
       serviceAccountName: bookinfo-ratings
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v1:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-ratings-v1:1.20.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -174,7 +174,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v1:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-reviews-v1:1.20.2
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -214,7 +214,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v2:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-reviews-v2:1.20.2
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -254,7 +254,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v3:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-reviews-v3:1.20.2
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -322,7 +322,7 @@ spec:
       serviceAccountName: bookinfo-productpage
       containers:
       - name: productpage
-        image: docker.io/istio/examples-bookinfo-productpage-v1:1.20.2
+        image: quay.io/sail-dev/examples-bookinfo-productpage-v1:1.20.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/helloworld/helloworld-dual-stack.yaml
+++ b/samples/helloworld/helloworld-dual-stack.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: helloworld
-        image: docker.io/istio/examples-helloworld-v1:1.0
+        image: quay.io/sail-dev/examples-helloworld-v1:1.0
         resources:
           requests:
             cpu: "100m"
@@ -66,7 +66,7 @@ spec:
     spec:
       containers:
       - name: helloworld
-        image: docker.io/istio/examples-helloworld-v2:1.0
+        image: quay.io/sail-dev/examples-helloworld-v2:1.0
         resources:
           requests:
             cpu: "100m"

--- a/samples/helloworld/helloworld.yaml
+++ b/samples/helloworld/helloworld.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: helloworld
-        image: docker.io/istio/examples-helloworld-v1:1.0
+        image: quay.io/sail-dev/examples-helloworld-v1:1.0
         resources:
           requests:
             cpu: "100m"
@@ -62,7 +62,7 @@ spec:
     spec:
       containers:
       - name: helloworld
-        image: docker.io/istio/examples-helloworld-v2:1.0
+        image: quay.io/sail-dev/examples-helloworld-v2:1.0
         resources:
           requests:
             cpu: "100m"

--- a/samples/httpbin/httpbin-nodeport.yaml
+++ b/samples/httpbin/httpbin-nodeport.yaml
@@ -48,7 +48,7 @@ spec:
         version: v1
     spec:
       containers:
-      - image: docker.io/mccutchen/go-httpbin:v2.15.0
+      - image: quay.io/sail-dev/go-httpbin:v2.15.0
         imagePullPolicy: IfNotPresent
         name: httpbin
         ports:

--- a/samples/httpbin/httpbin.yaml
+++ b/samples/httpbin/httpbin.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       serviceAccountName: httpbin
       containers:
-      - image: docker.io/mccutchen/go-httpbin:v2.15.0
+      - image: quay.io/sail-dev/go-httpbin:v2.15.0
         imagePullPolicy: IfNotPresent
         name: httpbin
         ports:

--- a/samples/tcp-echo/tcp-echo-dual-stack.yaml
+++ b/samples/tcp-echo/tcp-echo-dual-stack.yaml
@@ -54,7 +54,7 @@ spec:
     spec:
       containers:
       - name: tcp-echo
-        image: docker.io/istio/tcp-echo-server:1.3
+        image: quay.io/sail-dev/tcp-echo-server:1.3
         imagePullPolicy: IfNotPresent
         args: [ "9000,9001,9002", "hello" ]
         ports:

--- a/samples/tcp-echo/tcp-echo-ipv4.yaml
+++ b/samples/tcp-echo/tcp-echo-ipv4.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: tcp-echo
-        image: docker.io/istio/tcp-echo-server:1.3
+        image: quay.io/sail-dev/tcp-echo-server:1.3
         imagePullPolicy: IfNotPresent
         args: [ "9000,9001,9002", "hello" ]
         ports:

--- a/samples/tcp-echo/tcp-echo-ipv6.yaml
+++ b/samples/tcp-echo/tcp-echo-ipv6.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: tcp-echo
-        image: docker.io/istio/tcp-echo-server:1.3
+        image: quay.io/sail-dev/tcp-echo-server:1.3
         imagePullPolicy: IfNotPresent
         args: [ "9000,9001,9002", "hello" ]
         ports:

--- a/samples/tcp-echo/tcp-echo-services.yaml
+++ b/samples/tcp-echo/tcp-echo-services.yaml
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
       - name: tcp-echo
-        image: docker.io/istio/tcp-echo-server:1.3
+        image: quay.io/sail-dev/tcp-echo-server:1.3
         imagePullPolicy: IfNotPresent
         args: [ "9000,9001,9002", "one" ]
         ports:
@@ -78,7 +78,7 @@ spec:
     spec:
       containers:
       - name: tcp-echo
-        image: docker.io/istio/tcp-echo-server:1.3
+        image: quay.io/sail-dev/tcp-echo-server:1.3
         imagePullPolicy: IfNotPresent
         args: [ "9000,9001,9002", "two" ]
         ports:

--- a/samples/tcp-echo/tcp-echo.yaml
+++ b/samples/tcp-echo/tcp-echo.yaml
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
       - name: tcp-echo
-        image: docker.io/istio/tcp-echo-server:1.3
+        image: quay.io/sail-dev/tcp-echo-server:1.3
         imagePullPolicy: IfNotPresent
         args: [ "9000,9001,9002", "hello" ]
         ports:


### PR DESCRIPTION
**Please provide a description of this PR:**

Updates some examples to use `quay.io/sail-dev` instead of their `docker.io` counterparts. All of the images have already been mirrored into their respective `quay.io/sail-dev` repos using [crane copy](https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_copy.md).

There's a separate issue to automate this process: https://github.com/istio-ecosystem/sail-operator/issues/696

This also doesn't update _all_ of the examples. Only the ones that are currently used in OSSM docs or in the sail operator tests.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
