### PR TITLE
[release-1.24] OSSM-9076 Enable CA Bundle injection in only Gateway Namespaces

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -176,6 +176,27 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 				Run(stop)
 			return nil
 		})
+		if features.EnableGatewayAPICACertOnly {
+			s.addTerminatingStartFunc("gateway ca controller", func(stop <-chan struct{}) error {
+				leaderelection.
+					NewPerRevisionLeaderElection(args.Namespace, args.PodName, leaderelection.GatewayCAController, args.Revision, s.kubeClient).
+					AddRunFunction(func(leaderStop <-chan struct{}) {
+						// We can only run this if the Gateway CRD is created
+						if s.kubeClient.CrdWatcher().WaitForCRD(gvr.KubernetesGateway, leaderStop) {
+							controller := gateway.NewGatewayCAController(s.kubeClient, s.istiodCertBundleWatcher, args.Revision) // tagWatcher, args.Revision)
+							// Start informers again. This fixes the case where informers for namespace do not start,
+							// as we create them only after acquiring the leader lock
+							// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
+							// basically lazy loading the informer, if we stop it when we lose the lock we will never
+							// recreate it again.
+							s.kubeClient.RunAndWait(stop)
+							controller.Run(leaderStop)
+						}
+					}).
+					Run(stop)
+				return nil
+			})
+		}
 		if features.EnableGatewayAPIDeploymentController {
 			s.addTerminatingStartFunc("gateway deployment controller", func(stop <-chan struct{}) error {
 				leaderelection.

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1230,6 +1230,9 @@ func (s *Server) maybeCreateCA(caOpts *caOptions) error {
 // Returns true to indicate the K8S multicluster controller should enable replication of
 // root certificates to config maps in namespaces.
 func (s *Server) shouldStartNsController() bool {
+	if features.EnableGatewayAPICACertOnly {
+		return false
+	}
 	if s.isK8SSigning() {
 		// Need to distribute the roots from MeshConfig
 		return true

--- a/pilot/pkg/config/kube/gateway/gateway_ca_controller.go
+++ b/pilot/pkg/config/kube/gateway/gateway_ca_controller.go
@@ -1,0 +1,131 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gateway
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	gateway "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"istio.io/api/label"
+	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/keycertbundle"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/controllers"
+	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/security/pkg/k8s"
+)
+
+const (
+	// maxRetries is the number of times a gateway will be retried before it is dropped out of the queue.
+	// With the current rate-limiter in use (5ms*2^(maxRetries-1)) the following numbers represent the
+	// sequence of delays between successive queuing of a gateway.
+	//
+	// 5ms, 10ms, 20ms, 40ms, 80ms
+	maxRetries = 5
+)
+
+var (
+	// CACertNamespaceConfigMap is the name of the ConfigMap in each namespace storing the root cert of non-Kube CA.
+	CACertNamespaceConfigMap = features.CACertConfigMapName
+
+	configMapLabel = map[string]string{"istio.io/config": "true", "openshift.io/mesh": "true"}
+)
+
+// GatewayCAController manages reconciles a configmap in each namespace with a desired set of data.
+type GatewayCAController struct {
+	caBundleWatcher *keycertbundle.Watcher
+
+	queue controllers.Queue
+
+	gateways   kclient.Client[*gateway.Gateway]
+	configmaps kclient.Client[*v1.ConfigMap]
+}
+
+// NewGatewayCAController returns a pointer to a newly constructed GatewayCAController instance.
+func NewGatewayCAController(kubeClient kube.Client, caBundleWatcher *keycertbundle.Watcher, revision string) *GatewayCAController {
+	c := &GatewayCAController{
+		caBundleWatcher: caBundleWatcher,
+	}
+	c.queue = controllers.NewQueue("gateway ca controller",
+		controllers.WithReconciler(c.reconcileCACert),
+		controllers.WithMaxAttempts(maxRetries))
+
+	c.configmaps = kclient.NewFiltered[*v1.ConfigMap](kubeClient, kclient.Filter{
+		FieldSelector: "metadata.name=" + CACertNamespaceConfigMap,
+		ObjectFilter:  kube.FilterIfEnhancedFilteringEnabled(kubeClient),
+	})
+	c.gateways = kclient.NewFiltered[*gateway.Gateway](kubeClient, kclient.Filter{
+		ObjectFilter: kube.FilterIfEnhancedFilteringEnabled(kubeClient),
+	})
+	c.configmaps.AddEventHandler(controllers.ObjectHandler(c.queue.AddObject))
+
+	c.gateways.AddEventHandler(controllers.FilteredObjectSpecHandler(c.queue.AddObject, func(o controllers.Object) bool {
+		return o.GetLabels()[label.IoIstioRev.Name] == revision
+	}))
+	return c
+}
+
+// Run starts the GatewayCAController until a value is sent to stopCh.
+func (gwc *GatewayCAController) Run(stopCh <-chan struct{}) {
+	if !kube.WaitForCacheSync("gateway ca controller", stopCh, gwc.gateways.HasSynced, gwc.configmaps.HasSynced) {
+		return
+	}
+
+	go gwc.startCaBundleWatcher(stopCh)
+	gwc.queue.Run(stopCh)
+	controllers.ShutdownAll(gwc.configmaps, gwc.gateways)
+}
+
+// startCaBundleWatcher listens for updates to the CA bundle and update cm in each namespace
+func (gwc *GatewayCAController) startCaBundleWatcher(stop <-chan struct{}) {
+	id, watchCh := gwc.caBundleWatcher.AddWatcher()
+	defer gwc.caBundleWatcher.RemoveWatcher(id)
+	for {
+		select {
+		case <-watchCh:
+			for _, gw := range gwc.gateways.List("", labels.Everything()) {
+				gwc.gatewayChange(gw)
+			}
+		case <-stop:
+			return
+		}
+	}
+}
+
+// reconcileCACert will reconcile the ca root cert configmap for the specified namespace
+// If the configmap is not found, it will be created.
+func (gwc *GatewayCAController) reconcileCACert(o types.NamespacedName) error {
+	meta := metav1.ObjectMeta{
+		Name:      CACertNamespaceConfigMap,
+		Namespace: o.Namespace,
+		Labels:    configMapLabel,
+	}
+	return k8s.InsertDataToConfigMap(gwc.configmaps, meta, gwc.caBundleWatcher.GetCABundle())
+}
+
+// On gateway change, update the config map.
+// If terminating, this will be skipped
+func (gwc *GatewayCAController) gatewayChange(gw *gateway.Gateway) {
+	if gw.DeletionTimestamp == nil {
+		gwc.syncGateway(gw.Name, gw.Namespace)
+	}
+}
+
+func (gwc *GatewayCAController) syncGateway(name, namespace string) {
+	gwc.queue.Add(types.NamespacedName{Name: name, Namespace: namespace})
+}

--- a/pilot/pkg/config/kube/gateway/gateway_ca_controller_test.go
+++ b/pilot/pkg/config/kube/gateway/gateway_ca_controller_test.go
@@ -1,0 +1,155 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	gateway "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayapiclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+
+	"istio.io/api/label"
+	"istio.io/istio/pilot/pkg/keycertbundle"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+const (
+	TestRevision = "test"
+)
+
+func TestNamespaceControllerWithSameRevision(t *testing.T) {
+	client := kube.NewFakeClient()
+	t.Cleanup(client.Shutdown)
+	watcher := keycertbundle.NewWatcher()
+	caBundle := []byte("caBundle")
+	watcher.SetAndNotify(nil, nil, caBundle)
+	stop := test.NewStop(t)
+
+	nc := NewGatewayCAController(client, watcher, TestRevision)
+	client.RunAndWait(stop)
+	go nc.Run(stop)
+	retry.UntilOrFail(t, nc.queue.HasSynced)
+
+	expectedData := map[string]string{
+		constants.CACertNamespaceConfigMapDataName: string(caBundle),
+	}
+	createGateway(t, client.GatewayAPI(), "bar", "foo", map[string]string{label.IoIstioRev.Name: TestRevision})
+	expectConfigMap(t, nc.configmaps, CACertNamespaceConfigMap, "foo", expectedData)
+
+	// Make sure random configmap does not get updated
+	cmData := createConfigMap(t, client.Kube(), "not-root", "foo", "k")
+	expectConfigMap(t, nc.configmaps, "not-root", "foo", cmData)
+
+	newCaBundle := []byte("caBundle-new")
+	watcher.SetAndNotify(nil, nil, newCaBundle)
+	newData := map[string]string{
+		constants.CACertNamespaceConfigMapDataName: string(newCaBundle),
+	}
+	expectConfigMap(t, nc.configmaps, CACertNamespaceConfigMap, "foo", newData)
+
+	deleteConfigMap(t, client.Kube(), "foo")
+	expectConfigMap(t, nc.configmaps, CACertNamespaceConfigMap, "foo", newData)
+}
+
+func TestNamespaceControllerWithOtherRevision(t *testing.T) {
+	client := kube.NewFakeClient()
+	t.Cleanup(client.Shutdown)
+	watcher := keycertbundle.NewWatcher()
+	caBundle := []byte("caBundle")
+	watcher.SetAndNotify(nil, nil, caBundle)
+	stop := test.NewStop(t)
+
+	nc := NewGatewayCAController(client, watcher, TestRevision)
+	client.RunAndWait(stop)
+	go nc.Run(stop)
+	retry.UntilOrFail(t, nc.queue.HasSynced)
+
+	createGateway(t, client.GatewayAPI(), "bar", "foo", map[string]string{label.IoIstioRev.Name: "other-revision"})
+	expectConfigMapNotExist(t, nc.configmaps, "foo")
+}
+
+func deleteConfigMap(t *testing.T, client kubernetes.Interface, ns string) {
+	t.Helper()
+	_, err := client.CoreV1().ConfigMaps(ns).Get(context.TODO(), CACertNamespaceConfigMap, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.CoreV1().ConfigMaps(ns).Delete(context.TODO(), CACertNamespaceConfigMap, metav1.DeleteOptions{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createConfigMap(t *testing.T, client kubernetes.Interface, name, ns, key string) map[string]string {
+	t.Helper()
+	data := map[string]string{key: "v"}
+	_, err := client.CoreV1().ConfigMaps(ns).Create(context.Background(), &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Data: data,
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func createGateway(t *testing.T, client gatewayapiclient.Interface, n, ns string, labels map[string]string) {
+	t.Helper()
+	if _, err := client.GatewayV1beta1().Gateways(ns).Create(context.TODO(), &gateway.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: n, Labels: labels},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// nolint:unparam
+func expectConfigMap(t *testing.T, configmaps kclient.Client[*v1.ConfigMap], name, ns string, data map[string]string) {
+	t.Helper()
+	retry.UntilSuccessOrFail(t, func() error {
+		cm := configmaps.Get(name, ns)
+		if cm == nil {
+			return fmt.Errorf("not found")
+		}
+		if !reflect.DeepEqual(cm.Data, data) {
+			return fmt.Errorf("data mismatch, expected %+v got %+v", data, cm.Data)
+		}
+		return nil
+	}, retry.Timeout(time.Second*10))
+}
+
+func expectConfigMapNotExist(t *testing.T, configmaps kclient.Client[*v1.ConfigMap], ns string) {
+	t.Helper()
+	err := retry.Until(func() bool {
+		cm := configmaps.Get(CACertNamespaceConfigMap, ns)
+		return cm != nil
+	}, retry.Timeout(time.Millisecond*25))
+
+	if err == nil {
+		t.Fatalf("%s namespace should not have %s configmap.", ns, CACertNamespaceConfigMap)
+	}
+}

--- a/pilot/pkg/features/experimental.go
+++ b/pilot/pkg/features/experimental.go
@@ -210,4 +210,7 @@ var (
 
 	CACertConfigMapName = env.Register("PILOT_CA_CERT_CONFIGMAP", "istio-ca-root-cert",
 		"The name of the ConfigMap that stores the Root CA Certificate that is used by istiod").Get()
+
+	EnableGatewayAPICACertOnly = env.Register("PILOT_ENABLE_GATEWAY_API_CA_CERT_ONLY", false,
+		"If true, only namespaces containing a Gateway API Gateway will have the CA Bundle ConfigMap injected").Get()
 )

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -55,6 +55,7 @@ const (
 	// * This type is per-revision, so it is higher cost. Leases are cheaper
 	// * Other types use "prioritized leader election", which isn't implemented for Lease
 	GatewayDeploymentController = "istio-gateway-deployment"
+	GatewayCAController         = "istio-gateway-ca"
 	NodeUntaintController       = "istio-node-untaint"
 	IPAutoallocateController    = "istio-ip-autoallocate"
 )


### PR DESCRIPTION
**Please provide a description of this PR:**
When using istio as a pure Gateway API Ingress provider the
CA Bundle is only required where a Gateway exist. Avoid
spreading them out across all namespaces.
   
A flag has been added to enable the Gateway only behavior which also disables
the Namespace level injection. The new Gateway GA Controller behaves similar to
NamespaceController but watches primarly Gateway objects instead of Namespaces.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [x] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

Depends on #333 