### PR TITLE
[release-1.24] OSSM-8998 Disable istioctl commands with building ldflags

### DIFF
--- a/istioctl/cmd/ossm_custom_cmd.go
+++ b/istioctl/cmd/ossm_custom_cmd.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// The following fields are populated at build time using -ldflags -X.
+var (
+	// List of the disabled commands separated by a semicolon.
+	// Eg: go build ... -ldflags -X PACKAGE_NAME/istioctl/cmd.disabledCmds=command1;command2;command3
+	disabledCmds string
+
+	// Optional: General message that is printed for every disabled commands.
+	// Eg: go build ... -ldflags -X 'PACKAGE_NAME/istioctl/cmd.disabledCmdsMsg=command not supported in <this_context>'
+	disabledCmdsMsg string
+
+	// Optional: Additionnal information for specific commands.
+	// Eg: go build ... -X 'PACKAGE_NAME/istioctl/cmd.disabledCmdsExtraInfo=command1=extra info about cmd1;command2=extra info about cmd2'
+	disabledCmdsExtraInfo string
+)
+
+const (
+	defaultDisabledCmdsMsg = "command is disabled"
+)
+
+type disabledCommand struct {
+	name      string
+	extraInfo string
+}
+
+// newDisableCommands creates the map of disabled commands from the 'disabledCmds' build ldflag.
+func newDisableCommands(buildDisableCmds, buildExtraInfo string) map[string]*disabledCommand {
+	commands := make(map[string]*disabledCommand)
+	cmds := strings.Split(buildDisableCmds, ";")
+	extra := strings.Split(buildExtraInfo, ";")
+
+	// Adding disabled commands into the map
+	for _, c := range cmds {
+		commands[c] = &disabledCommand{
+			name: c,
+		}
+	}
+
+	// Setting the extra info for specific disabled commands
+	for _, e := range extra {
+		extraInfo := strings.SplitN(e, "=", 2)
+		if len(extraInfo) == 2 {
+			commands[extraInfo[0]].extraInfo = extraInfo[1]
+		}
+	}
+	return commands
+}
+
+// disableCmd is used to set and return a command as disabled.
+func disableCmd(cmd *cobra.Command, message, extraInfo string) *cobra.Command {
+	cmdName := cmd.Name()
+
+	msg := fmt.Sprintf("`%s` %s", cmdName, defaultDisabledCmdsMsg)
+
+	if len(message) > 0 {
+		msg = fmt.Sprintf("`%s` %s", cmdName, message)
+	}
+
+	if len(extraInfo) > 0 {
+		msg = fmt.Sprintf("%s. Info: %s", msg, extraInfo)
+	}
+
+	return &cobra.Command{
+		Use:   cmdName,
+		Short: msg,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return errors.New(msg)
+		},
+	}
+}
+
+// disableCmds disables all the flagged "disabled" commands.
+func disableCmds(root *cobra.Command) {
+	disabledCommands := newDisableCommands(disabledCmds, disabledCmdsExtraInfo)
+	for _, childCmd := range root.Commands() {
+		if cmd, disabled := disabledCommands[childCmd.Name()]; disabled {
+			root.RemoveCommand(childCmd)
+			root.AddCommand(disableCmd(childCmd, disabledCmdsMsg, cmd.extraInfo))
+		}
+	}
+}

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -143,7 +143,7 @@ debug and diagnose their Istio mesh.
 
 	kubeInjectCmd := kubeinject.InjectCommand(ctx)
 	hideInheritedFlags(kubeInjectCmd, cli.FlagNamespace)
-	rootCmd.AddCommand(unsupportedCmd(kubeInjectCmd, "set the `istio-injection=enabled` label"))
+	rootCmd.AddCommand(kubeInjectCmd)
 
 	experimentalCmd := &cobra.Command{
 		Use:     "experimental",
@@ -187,10 +187,10 @@ debug and diagnose their Istio mesh.
 	rootCmd.AddCommand(admin.Cmd(ctx))
 	experimentalCmd.AddCommand(injector.Cmd(ctx))
 
-	rootCmd.AddCommand(unsupportedCmd(mesh.UninstallCmd(ctx), "delete Istio CR"))
+	rootCmd.AddCommand(mesh.UninstallCmd(ctx))
 
-	experimentalCmd.AddCommand(unsupportedCmd(authz.AuthZ(ctx), "none"))
-	rootCmd.AddCommand(unsupportedCmd(authz.AuthZ(ctx), "none"))
+	experimentalCmd.AddCommand(authz.AuthZ(ctx))
+	rootCmd.AddCommand(seeExperimentalCmd("authz"))
 	experimentalCmd.AddCommand(metrics.Cmd(ctx))
 	experimentalCmd.AddCommand(describe.Cmd(ctx))
 	experimentalCmd.AddCommand(config.Cmd())
@@ -209,27 +209,27 @@ debug and diagnose their Istio mesh.
 
 	dashboardCmd := dashboard.Dashboard(ctx)
 	hideInheritedFlags(dashboardCmd, cli.FlagNamespace, cli.FlagIstioNamespace)
-	rootCmd.AddCommand(unsupportedCmd(dashboardCmd, "use Kiali"))
+	rootCmd.AddCommand(dashboardCmd)
 
 	manifestCmd := mesh.ManifestCmd(ctx)
 	hideInheritedFlags(manifestCmd, cli.FlagNamespace, cli.FlagIstioNamespace, FlagCharts)
-	rootCmd.AddCommand(unsupportedCmd(manifestCmd, "none"))
+	rootCmd.AddCommand(manifestCmd)
 
 	installCmd := mesh.InstallCmd(ctx)
 	hideInheritedFlags(installCmd, cli.FlagNamespace, cli.FlagIstioNamespace, FlagCharts)
-	rootCmd.AddCommand(unsupportedCmd(installCmd, "create Istio CR"))
+	rootCmd.AddCommand(installCmd)
 
 	upgradeCmd := mesh.UpgradeCmd(ctx)
 	hideInheritedFlags(upgradeCmd, cli.FlagNamespace, cli.FlagIstioNamespace, FlagCharts)
-	rootCmd.AddCommand(unsupportedCmd(upgradeCmd, "update spec.version in Istio CR"))
+	rootCmd.AddCommand(upgradeCmd)
 
 	bugReportCmd := bugreport.Cmd(ctx, root.LoggingOptions)
 	hideInheritedFlags(bugReportCmd, cli.FlagNamespace, cli.FlagIstioNamespace)
-	rootCmd.AddCommand(unsupportedCmd(bugReportCmd, "use istio-must-gather"))
+	rootCmd.AddCommand(bugReportCmd)
 
 	tagCmd := tag.TagCommand(ctx)
 	hideInheritedFlags(tag.TagCommand(ctx), cli.FlagNamespace, cli.FlagIstioNamespace, FlagCharts)
-	rootCmd.AddCommand(unsupportedCmd(tagCmd, "use IstioRevisionTag CR"))
+	rootCmd.AddCommand(tagCmd)
 
 	// leave the multicluster commands in x for backwards compat
 	rootCmd.AddCommand(multicluster.NewCreateRemoteSecretCommand(ctx))
@@ -268,6 +268,8 @@ debug and diagnose their Istio mesh.
 		})
 	}
 
+	disableCmds(rootCmd)
+
 	return rootCmd
 }
 
@@ -290,24 +292,10 @@ func ConfigureLogging(_ *cobra.Command, _ []string) error {
 // Other alternative
 // for graduatedCmd see https://github.com/istio/istio/pull/26408
 // for softGraduatedCmd see https://github.com/istio/istio/pull/26563
-// nolint: unused
 func seeExperimentalCmd(name string) *cobra.Command {
 	msg := fmt.Sprintf("(%s is experimental. Use `istioctl experimental %s`)", name, name)
 	return &cobra.Command{
 		Use:   name,
-		Short: msg,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return errors.New(msg)
-		},
-	}
-}
-
-// unsupportedCmd is used to set commands that are not supported for OpenShift Service Mesh.
-func unsupportedCmd(cmd *cobra.Command, alternative string) *cobra.Command {
-	cmdName := cmd.Name()
-	msg := fmt.Sprintf("Command `%s` not supported in OpenShift Service Mesh context. Alternative: %s", cmdName, alternative)
-	return &cobra.Command{
-		Use:   cmdName,
 		Short: msg,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return errors.New(msg)


### PR DESCRIPTION
* Disable istioctl commands with building ldflags



* Refactoring



* Refactoring and compacting functions



* Remove disabled parameter



---------

**Please provide a description of this PR:**

Manual cherry-pick of #312 

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
