### PR TITLE
Revert "Add retry timeouts delay for AWS LB (#227)"

### DIFF
--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -4270,11 +4270,6 @@ spec:
 				Headers: headersWithToken2,
 			},
 			Check: check.Status(http.StatusOK),
-			// Retry with a longer duration until the AWS LB is available
-			// TODO: Fix it properly as recommended https://github.com/istio/istio/pull/54244#pullrequestreview-2489497585
-			Retry: echo.Retry{
-				Options: []retry.Option{retry.Timeout(2 * time.Minute)},
-			},
 		},
 		setupOpts: setHostHeader,
 	})
@@ -4304,11 +4299,6 @@ spec:
 				Headers: headersWithToken2,
 			},
 			Check: check.Status(http.StatusOK),
-			// Retry with a longer duration until the AWS LB is available
-			// TODO: Fix it properly as recommended https://github.com/istio/istio/pull/54244#pullrequestreview-2489497585
-			Retry: echo.Retry{
-				Options: []retry.Option{retry.Timeout(2 * time.Minute)},
-			},
 		},
 		setupOpts: setHostHeader,
 	})


### PR DESCRIPTION
This reverts commit 34ea3e82c6894f0a51f0d5cf1581542292018c24.

**Please provide a description of this PR:**

Test if this is still causing an issue

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
