### PR TITLE
Add Ambient flow to Sail Operator Control Plane deploy for Integ tests

### DIFF
--- a/prow/config/sail-operator/ztunnel.yaml
+++ b/prow/config/sail-operator/ztunnel.yaml
@@ -1,0 +1,8 @@
+apiVersion: sailoperator.io/v1alpha1
+kind: ZTunnel
+metadata:
+  name: default
+spec:
+  namespace: ${ZTUNNEL_NAMESPACE}
+  version: ${ISTIO_VERSION}
+  profile: ambient


### PR DESCRIPTION
**Please provide a description of this PR:**
When external control plane is used during Istio integration tests execution and we are deploying Sail Operator, we would like to support Ambient mode as well.

Add Ambient mode support to the deployment of Sail Operator control plane.
Deployment of Ambient mode would be controlled by AMBIENT=true/false environment variable.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
