### PR TITLE
release-1.26 Gateway Conformance Test Fixes

### DIFF
--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -223,6 +223,12 @@ func init() {
 	flag.BoolVar(&settingsFromCommandLine.OpenShift, "istio.test.openshift", settingsFromCommandLine.OpenShift,
 		"Indicate the tests run in an OpenShift platform rather than in plain Kubernetes.")
 
+	flag.BoolVar(
+		&settingsFromCommandLine.GatewayConformanceAllowCRDsMismatch,
+		"istio.test.GatewayConformanceAllowCRDsMismatch",
+		settingsFromCommandLine.GatewayConformanceAllowCRDsMismatch,
+		"If set, gateway conformance tests will run even if the environment has pre-installed Gateway API CRDs that differ from the current Gateway API version.",
+	)
 	initGatewayConformanceTimeouts()
 }
 

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -185,6 +185,9 @@ type Settings struct {
 
 	GatewayConformanceTimeoutConfig gwConformanceConfig.TimeoutConfig
 
+	// GatewayConformanceAllowCRDsMismatch lets gateway conformance tests to run on environments with pre-installed gateway-api CRDs
+	GatewayConformanceAllowCRDsMismatch bool
+
 	// OpenShift indicates the tests run in an OpenShift platform rather than in plain Kubernetes.
 	OpenShift bool
 }
@@ -268,6 +271,7 @@ func (s *Settings) String() string {
 	result += fmt.Sprintf("HelmRepo:          						 %v\n", s.HelmRepo)
 	result += fmt.Sprintf("IPFamilies:							 %v\n", s.IPFamilies)
 	result += fmt.Sprintf("GatewayConformanceStandardOnly: %v\n", s.GatewayConformanceStandardOnly)
+	result += fmt.Sprintf("GatewayConformanceAllowCRDsMismatch: %v\n", s.GatewayConformanceAllowCRDsMismatch)
 	return result
 }
 

--- a/prow/config/sail-operator/istio-gw-api-coredns-fix.patch
+++ b/prow/config/sail-operator/istio-gw-api-coredns-fix.patch
@@ -1,0 +1,771 @@
+commit 5c75a7acc2dfc0dd9c4c3af04f2967015933c9fa
+Author: Andrej Smigala <asmigala@redhat.com>
+Date:   Tue Oct 15 12:21:25 2024 +0200
+
+    Fix gateway conformance on OCP
+
+diff --git a/tests/integration/pilot/gateway_conformance_test.go b/tests/integration/pilot/gateway_conformance_test.go
+index 8bcade301e..4a70d7fc23 100644
+--- a/tests/integration/pilot/gateway_conformance_test.go
++++ b/tests/integration/pilot/gateway_conformance_test.go
+@@ -104,6 +104,7 @@ func TestGatewayConformance(t *testing.T) {
+ 			hostnameType := v1.AddressType("Hostname")
+ 			istioVersion, _ := env.ReadVersion()
+ 			opts := suite.ConformanceOptions{
++				BaseManifests:           "gateway-conformance-manifests.yaml",
+ 				Client:                   c,
+ 				Clientset:                gatewayConformanceInputs.Client.Kube(),
+ 				ClientOptions:            clientOptions,
+@@ -111,6 +113,6 @@ func TestGatewayConformance(t *testing.T) {
+ 				GatewayClassName:         "istio",
+ 				Debug:                    scopes.Framework.DebugEnabled(),
+ 				CleanupBaseResources:     gatewayConformanceInputs.Cleanup,
+-				ManifestFS:               []fs.FS{&conformance.Manifests},
++				ManifestFS:               []fs.FS{os.DirFS("testdata"), &conformance.Manifests},
+ 				SupportedFeatures:        features.SetsToNamesSet(supportedFeatures),
+ 				SkipTests:                maps.Keys(skippedTests),
+diff --git a/tests/integration/pilot/testdata/gateway-conformance-manifests.yaml b/tests/integration/pilot/testdata/gateway-conformance-manifests.yaml
+new file mode 100644
+index 0000000000..d78c853007
+--- /dev/null
++++ b/tests/integration/pilot/testdata/gateway-conformance-manifests.yaml
+@@ -0,0 +1,739 @@
++# This file contains the base resources that most conformance tests will rely
++# on. This includes 3 namespaces along with Gateways, Services and Deployments
++# that can be used as backends for routing traffic. The most important
++# resources included are the Gateways (all in the gateway-conformance-infra
++# namespace):
++# - same-namespace (only supports route in same ns)
++# - all-namespaces (supports routes in all ns)
++# - backend-namespaces (supports routes in ns with backend label)
++apiVersion: v1
++kind: Namespace
++metadata:
++  name: gateway-conformance-infra
++  labels:
++    gateway-conformance: infra
++---
++apiVersion: gateway.networking.k8s.io/v1beta1
++kind: Gateway
++metadata:
++  name: same-namespace
++  namespace: gateway-conformance-infra
++spec:
++  gatewayClassName: "{GATEWAY_CLASS_NAME}"
++  listeners:
++  - name: http
++    port: 80
++    protocol: HTTP
++    allowedRoutes:
++      namespaces:
++        from: Same
++---
++apiVersion: gateway.networking.k8s.io/v1beta1
++kind: Gateway
++metadata:
++  name: same-namespace-with-https-listener
++  namespace: gateway-conformance-infra
++spec:
++  gatewayClassName: "{GATEWAY_CLASS_NAME}"
++  listeners:
++  - name: https
++    port: 443
++    protocol: HTTPS
++    allowedRoutes:
++      namespaces:
++        from: Same
++    tls:
++      certificateRefs:
++      - group: ""
++        kind: Secret
++        name: tls-validity-checks-certificate
++        namespace: gateway-conformance-infra
++  - name: https-with-hostname
++    port: 443
++    hostname: second-example.org
++    protocol: HTTPS
++    allowedRoutes:
++      namespaces:
++        from: Same
++    tls:
++      certificateRefs:
++      - group: ""
++        kind: Secret
++        name: tls-validity-checks-certificate
++        namespace: gateway-conformance-infra
++---
++apiVersion: gateway.networking.k8s.io/v1beta1
++kind: Gateway
++metadata:
++  name: all-namespaces
++  namespace: gateway-conformance-infra
++spec:
++  gatewayClassName: "{GATEWAY_CLASS_NAME}"
++  listeners:
++  - name: http
++    port: 80
++    protocol: HTTP
++    allowedRoutes:
++      namespaces:
++        from: All
++---
++apiVersion: gateway.networking.k8s.io/v1beta1
++kind: Gateway
++metadata:
++  name: backend-namespaces
++  namespace: gateway-conformance-infra
++spec:
++  gatewayClassName: "{GATEWAY_CLASS_NAME}"
++  listeners:
++  - name: http
++    port: 80
++    protocol: HTTP
++    allowedRoutes:
++      namespaces:
++        from: Selector
++        selector:
++          matchLabels:
++            gateway-conformance: backend
++---
++apiVersion: v1
++kind: Service
++metadata:
++  name: infra-backend-v1
++  namespace: gateway-conformance-infra
++spec:
++  selector:
++    app: infra-backend-v1
++  ports:
++  - name: first-port
++    protocol: TCP
++    port: 8080
++    targetPort: 3000
++  - name: second-port
++    protocol: TCP
++    appProtocol: kubernetes.io/h2c
++    port: 8081
++    targetPort: 3001
++  - name: third-port
++    protocol: TCP
++    appProtocol: kubernetes.io/ws
++    port: 8082
++    targetPort: 3000
++---
++apiVersion: apps/v1
++kind: Deployment
++metadata:
++  name: infra-backend-v1
++  namespace: gateway-conformance-infra
++  labels:
++    app: infra-backend-v1
++spec:
++  replicas: 2
++  selector:
++    matchLabels:
++      app: infra-backend-v1
++  template:
++    metadata:
++      labels:
++        app: infra-backend-v1
++    spec:
++      containers:
++      - name: infra-backend-v1
++        # From https://github.com/kubernetes-sigs/ingress-controller-conformance/tree/master/images/echoserver
++        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
++        env:
++        - name: POD_NAME
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.name
++        - name: NAMESPACE
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.namespace
++        resources:
++          requests:
++            cpu: 10m
++---
++apiVersion: v1
++kind: Service
++metadata:
++  name: infra-backend-v2
++  namespace: gateway-conformance-infra
++spec:
++  selector:
++    app: infra-backend-v2
++  ports:
++  - protocol: TCP
++    port: 8080
++    targetPort: 3000
++---
++apiVersion: apps/v1
++kind: Deployment
++metadata:
++  name: infra-backend-v2
++  namespace: gateway-conformance-infra
++  labels:
++    app: infra-backend-v2
++spec:
++  replicas: 2
++  selector:
++    matchLabels:
++      app: infra-backend-v2
++  template:
++    metadata:
++      labels:
++        app: infra-backend-v2
++    spec:
++      containers:
++      - name: infra-backend-v2
++        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
++        env:
++        - name: POD_NAME
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.name
++        - name: NAMESPACE
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.namespace
++        resources:
++          requests:
++            cpu: 10m
++---
++apiVersion: v1
++kind: Service
++metadata:
++  name: infra-backend-v3
++  namespace: gateway-conformance-infra
++spec:
++  selector:
++    app: infra-backend-v3
++  ports:
++  - protocol: TCP
++    port: 8080
++    targetPort: 3000
++---
++apiVersion: apps/v1
++kind: Deployment
++metadata:
++  name: infra-backend-v3
++  namespace: gateway-conformance-infra
++  labels:
++    app: infra-backend-v3
++spec:
++  replicas: 2
++  selector:
++    matchLabels:
++      app: infra-backend-v3
++  template:
++    metadata:
++      labels:
++        app: infra-backend-v3
++    spec:
++      containers:
++      - name: infra-backend-v3
++        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
++        env:
++        - name: POD_NAME
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.name
++        - name: NAMESPACE
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.namespace
++        resources:
++          requests:
++            cpu: 10m
++---
++apiVersion: v1
++kind: Service
++metadata:
++  name: tls-backend
++  namespace: gateway-conformance-infra
++spec:
++  selector:
++    app: tls-backend
++  ports:
++  - protocol: TCP
++    port: 443
++    targetPort: 8443
++---
++apiVersion: apps/v1
++kind: Deployment
++metadata:
++  name: tls-backend
++  namespace: gateway-conformance-infra
++  labels:
++    app: tls-backend
++spec:
++  replicas: 1
++  selector:
++    matchLabels:
++      app: tls-backend
++  template:
++    metadata:
++      labels:
++        app: tls-backend
++    spec:
++      containers:
++      - name: tls-backend
++        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
++        volumeMounts:
++        - name: secret-volume
++          mountPath: /etc/secret-volume
++        env:
++        - name: POD_NAME
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.name
++        - name: NAMESPACE
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.namespace
++        - name: TLS_SERVER_CERT
++          value: /etc/secret-volume/crt
++        - name: TLS_SERVER_PRIVKEY
++          value: /etc/secret-volume/key
++        resources:
++          requests:
++            cpu: 10m
++      volumes:
++      - name: secret-volume
++        secret:
++          secretName: tls-passthrough-checks-certificate
++          items:
++          - key: tls.crt
++            path: crt
++          - key: tls.key
++            path: key
++---
++apiVersion: v1
++kind: Namespace
++metadata:
++  name: gateway-conformance-app-backend
++  labels:
++    gateway-conformance: backend
++---
++apiVersion: v1
++kind: Service
++metadata:
++  name: tls-backend
++  namespace: gateway-conformance-app-backend
++spec:
++  selector:
++    app: tls-backend
++  ports:
++  - protocol: TCP
++    port: 443
++    targetPort: 8443
++---
++apiVersion: apps/v1
++kind: Deployment
++metadata:
++  name: tls-backend
++  namespace: gateway-conformance-app-backend
++  labels:
++    app: tls-backend
++spec:
++  replicas: 1
++  selector:
++    matchLabels:
++      app: tls-backend
++  template:
++    metadata:
++      labels:
++        app: tls-backend
++    spec:
++      containers:
++      - name: tls-backend
++        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
++        volumeMounts:
++        - name: secret-volume
++          mountPath: /etc/secret-volume
++        env:
++        - name: POD_NAME
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.name
++        - name: NAMESPACE
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.namespace
++        - name: TLS_SERVER_CERT
++          value: /etc/secret-volume/crt
++        - name: TLS_SERVER_PRIVKEY
++          value: /etc/secret-volume/key
++        resources:
++          requests:
++            cpu: 10m
++      volumes:
++      - name: secret-volume
++        secret:
++          secretName: tls-passthrough-checks-certificate
++          items:
++          - key: tls.crt
++            path: crt
++          - key: tls.key
++            path: key
++---
++apiVersion: v1
++kind: Service
++metadata:
++  name: app-backend-v1
++  namespace: gateway-conformance-app-backend
++spec:
++  selector:
++    app: app-backend-v1
++  ports:
++  - protocol: TCP
++    port: 8080
++    targetPort: 3000
++---
++apiVersion: apps/v1
++kind: Deployment
++metadata:
++  name: app-backend-v1
++  namespace: gateway-conformance-app-backend
++  labels:
++    app: app-backend-v1
++spec:
++  replicas: 2
++  selector:
++    matchLabels:
++      app: app-backend-v1
++  template:
++    metadata:
++      labels:
++        app: app-backend-v1
++    spec:
++      containers:
++      - name: app-backend-v1
++        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
++        env:
++        - name: POD_NAME
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.name
++        - name: NAMESPACE
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.namespace
++        resources:
++          requests:
++            cpu: 10m
++---
++apiVersion: v1
++kind: Service
++metadata:
++  name: app-backend-v2
++  namespace: gateway-conformance-app-backend
++spec:
++  selector:
++    app: app-backend-v2
++  ports:
++  - protocol: TCP
++    port: 8080
++    targetPort: 3000
++---
++apiVersion: apps/v1
++kind: Deployment
++metadata:
++  name: app-backend-v2
++  namespace: gateway-conformance-app-backend
++  labels:
++    app: app-backend-v2
++spec:
++  replicas: 2
++  selector:
++    matchLabels:
++      app: app-backend-v2
++  template:
++    metadata:
++      labels:
++        app: app-backend-v2
++    spec:
++      containers:
++      - name: app-backend-v2
++        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
++        env:
++        - name: POD_NAME
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.name
++        - name: NAMESPACE
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.namespace
++        resources:
++          requests:
++            cpu: 10m
++---
++apiVersion: v1
++kind: Namespace
++metadata:
++  name: gateway-conformance-web-backend
++  labels:
++    gateway-conformance: backend
++---
++apiVersion: v1
++kind: Service
++metadata:
++  name: web-backend
++  namespace: gateway-conformance-web-backend
++spec:
++  selector:
++    app: web-backend
++  ports:
++  - protocol: TCP
++    port: 8080
++    targetPort: 3000
++---
++apiVersion: apps/v1
++kind: Deployment
++metadata:
++  name: web-backend
++  namespace: gateway-conformance-web-backend
++  labels:
++    app: web-backend
++spec:
++  replicas: 2
++  selector:
++    matchLabels:
++      app: web-backend
++  template:
++    metadata:
++      labels:
++        app: web-backend
++    spec:
++      containers:
++      - name: web-backend
++        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
++        env:
++        - name: POD_NAME
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.name
++        - name: NAMESPACE
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.namespace
++        resources:
++          requests:
++            cpu: 10m
++---
++apiVersion: v1
++kind: Service
++metadata:
++  name: grpc-infra-backend-v1
++  namespace: gateway-conformance-infra
++spec:
++  selector:
++    app: grpc-infra-backend-v1
++  ports:
++  - protocol: TCP
++    port: 8080
++    targetPort: 3000
++    appProtocol: kubernetes.io/h2c
++---
++apiVersion: apps/v1
++kind: Deployment
++metadata:
++  name: grpc-infra-backend-v1
++  namespace: gateway-conformance-infra
++  labels:
++    app: grpc-infra-backend-v1
++spec:
++  replicas: 2
++  selector:
++    matchLabels:
++      app: grpc-infra-backend-v1
++  template:
++    metadata:
++      labels:
++        app: grpc-infra-backend-v1
++    spec:
++      containers:
++      - name: grpc-infra-backend-v1
++        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
++        env:
++        - name: POD_NAME
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.name
++        - name: NAMESPACE
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.namespace
++        - name: GRPC_ECHO_SERVER
++          value: "1"
++        resources:
++          requests:
++            cpu: 10m
++---
++apiVersion: v1
++kind: Service
++metadata:
++  name: grpc-infra-backend-v2
++  namespace: gateway-conformance-infra
++spec:
++  selector:
++    app: grpc-infra-backend-v2
++  ports:
++  - protocol: TCP
++    port: 8080
++    targetPort: 3000
++    appProtocol: kubernetes.io/h2c
++---
++apiVersion: apps/v1
++kind: Deployment
++metadata:
++  name: grpc-infra-backend-v2
++  namespace: gateway-conformance-infra
++  labels:
++    app: grpc-infra-backend-v2
++spec:
++  replicas: 2
++  selector:
++    matchLabels:
++      app: grpc-infra-backend-v2
++  template:
++    metadata:
++      labels:
++        app: grpc-infra-backend-v2
++    spec:
++      containers:
++      - name: grpc-infra-backend-v2
++        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
++        env:
++        - name: POD_NAME
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.name
++        - name: NAMESPACE
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.namespace
++        - name: GRPC_ECHO_SERVER
++          value: "1"
++        resources:
++          requests:
++            cpu: 10m
++---
++apiVersion: v1
++kind: Service
++metadata:
++  name: grpc-infra-backend-v3
++  namespace: gateway-conformance-infra
++spec:
++  selector:
++    app: grpc-infra-backend-v3
++  ports:
++  - protocol: TCP
++    port: 8080
++    targetPort: 3000
++    appProtocol: kubernetes.io/h2c
++---
++apiVersion: apps/v1
++kind: Deployment
++metadata:
++  name: grpc-infra-backend-v3
++  namespace: gateway-conformance-infra
++  labels:
++    app: grpc-infra-backend-v3
++spec:
++  replicas: 2
++  selector:
++    matchLabels:
++      app: grpc-infra-backend-v3
++  template:
++    metadata:
++      labels:
++        app: grpc-infra-backend-v3
++    spec:
++      containers:
++      - name: grpc-infra-backend-v3
++        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
++        env:
++        - name: POD_NAME
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.name
++        - name: NAMESPACE
++          valueFrom:
++            fieldRef:
++              fieldPath: metadata.namespace
++        - name: GRPC_ECHO_SERVER
++          value: "1"
++        resources:
++          requests:
++            cpu: 10m
++---
++apiVersion: v1
++kind: Service
++metadata:
++  name: coredns
++  namespace: gateway-conformance-infra
++  labels:
++    app: udp
++spec:
++  ports:
++  - name: udp-dns
++    port: 53
++    protocol: UDP
++    targetPort: 53
++  selector:
++    app: udp
++---
++apiVersion: apps/v1
++kind: Deployment
++metadata:
++  name: coredns
++  namespace: gateway-conformance-infra
++  labels:
++    app: udp
++spec:
++  selector:
++    matchLabels:
++      app: udp
++  template:
++    metadata:
++      labels:
++        app: udp
++    spec:
++      containers:
++      - args:
++        - -conf
++        - /root/Corefile
++        image: coredns/coredns
++        name: coredns
++        securityContext:
++          allowPrivilegeEscalation: false
++          capabilities:
++            add:
++            - NET_BIND_SERVICE
++            drop:
++            - all
++        volumeMounts:
++        - mountPath: /root
++          name: conf
++      volumes:
++      - configMap:
++          defaultMode: 420
++          name: coredns
++        name: conf
++---
++apiVersion: v1
++kind: ConfigMap
++metadata:
++  name: coredns
++  namespace: gateway-conformance-infra
++data:
++  Corefile: |
++    .:53 {
++        forward . 8.8.8.8 9.9.9.9
++        log
++        errors
++    }
++    foo.bar.com:53 {
++      whoami
++    }

--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -34,6 +34,7 @@ INSTALL_SAIL_OPERATOR="${INSTALL_SAIL_OPERATOR:-"false"}"
 TRUSTED_ZTUNNEL_NAMESPACE="${TRUSTED_ZTUNNEL_NAMESPACE:-"istio-system"}"
 AMBIENT="${AMBIENT:="false"}"
 DEPLOY_GATEWAY_API="false"
+TEST_HUB="${TEST_HUB:="image-registry.openshift-image-registry.svc:5000/${NAMESPACE}"}"
 
 # Important: SKIP_TEST_RUN is a workaround until downstream tests can be executed by using this script. 
 # To execute the tests in downstream, set SKIP_TEST_RUN to true
@@ -98,13 +99,13 @@ elif [ "${INSTALL_METALLB}" != "true" ] && [ "${SKIP_SETUP}" != "true" ]; then
     # Build and push the images to the internal registry
     build_images
 
+    # Install Sail Operator
+    if [ "${INSTALL_SAIL_OPERATOR}" == "true" ]; then
+        deploy_operator
+    fi
+
 else
     echo "Skipping the setup"
-fi
-
-# Install Sail Operator
-if [ "${INSTALL_SAIL_OPERATOR}" == "true" ]; then
-    deploy_operator
 fi
 
 # Check if the test run should be skipped
@@ -118,8 +119,10 @@ fi
 # Run the integration tests
 echo "Running integration tests"
 
-# Set the HUB to the internal registry svc URL to avoid the need to authenticate to pull images
-HUB="image-registry.openshift-image-registry.svc:5000/${NAMESPACE}"
+# Set gcr.io as mirror to docker.io/istio to be able to get images in downstream tests.
+if [ "${TEST_HUB}" == "docker.io/istio" ]; then
+    addGcrMirror
+fi
 
 # Check OCP version
 if ! OCP_VERSION_FULL=$(oc get clusterversion version -o jsonpath='{.status.desired.version}' 2>/dev/null); then
@@ -163,7 +166,7 @@ base_cmd=("go" "test" "-p" "1" "-v" "-count=1" "-tags=integ" "-vet=off" "-timeou
           "--istio.test.skipTProxy=true"
           "--istio.test.skipVM=true"
           "--istio.test.istio.enableCNI=true"
-          "--istio.test.hub=${HUB}"
+          "--istio.test.hub=${TEST_HUB}"
           "--istio.test.tag=${TAG}"
           "--istio.test.kube.deployGatewayAPI=${DEPLOY_GATEWAY_API}"
           "--istio.test.openshift")

--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -170,6 +170,16 @@ base_cmd=("go" "test" "-p" "1" "-v" "-count=1" "-tags=integ" "-vet=off" "-timeou
 
 helm_values="global.platform=openshift"
 
+# Gateway Conformance Test related modifications
+if [ "${TEST_SUITE}" == "pilot" ]; then
+    # Until OCP 4.19 default CRDs has https://github.com/kubernetes-sigs/gateway-api/pull/3389 we need following patch
+    git apply --verbose --reject --whitespace=fix --ignore-space-change ./prow/config/sail-operator/istio-gw-api-coredns-fix.patch
+    # This flag we need to run the conformance test even if the CRDs are not matching with the desired ones in go.mod
+    base_cmd+=("--istio.test.GatewayConformanceAllowCRDsMismatch=true")
+    # Stops flaky runs in public clouds
+    base_cmd+=("--istio.test.gatewayConformance.maxTimeToConsistency=180s")
+fi
+
 # If ambient mode executed, add "ambient" profile and args
 if [ "${AMBIENT}" == "true" ]; then
     base_cmd+=("--istio.test.ambient")

--- a/prow/setup/ocp_setup.sh
+++ b/prow/setup/ocp_setup.sh
@@ -113,6 +113,33 @@ items:
 ' | oc apply -f -
 }
 
+# Set gcr.io as mirror to docker.io/istio to be able to get images in downstream tests.
+function addGcrMirror(){
+  oc apply -f - <<__EOF__
+apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  name: docker-images-from-gcr
+spec:
+  imageDigestMirrors:
+  - mirrors:
+    - mirror.gcr.io
+    source: docker.io
+    mirrorSourcePolicy: NeverContactSource
+---
+apiVersion: config.openshift.io/v1
+kind: ImageTagMirrorSet
+metadata:
+  name: docker-images-from-gcr
+spec:
+  imageTagMirrors:
+  - mirrors:
+    - mirror.gcr.io
+    source: docker.io
+    mirrorSourcePolicy: NeverContactSource
+__EOF__
+}
+
 # Deploy MetalLB in the OCP cluster and configure IP address pool
 function deployMetalLB() {
   # Create the metallb-system namespace

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -140,6 +140,9 @@ func TestGatewayConformance(t *testing.T) {
 					"istio-injection": "enabled",
 				}
 			}
+			if ctx.Settings().GatewayConformanceAllowCRDsMismatch {
+				opts.AllowCRDsMismatch = true
+			}
 			ctx.Cleanup(func() {
 				if !ctx.Failed() {
 					return


### PR DESCRIPTION
Cherry-pick into release-1.26 branch of some tests fixes.

- Add mechanism to execute integration tests against downstream builds. 
- Modifications for running Gateway Conformance Test Suite on OCP 4.19


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
