### PR TITLE
manifests: add NetworkPolicy to istio-cni chart

### DIFF
--- a/manifests/charts/istio-cni/templates/networkpolicy.yaml
+++ b/manifests/charts/istio-cni/templates/networkpolicy.yaml
@@ -1,0 +1,37 @@
+{{- if (.Values.networkPolicy).enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "name" . }}{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: {{ template "name" . }}-node
+    release: {{ .Release.Name }}
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Cni"
+    app.kubernetes.io/name: {{ template "name" . }}
+    {{- include "istio.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: {{ template "name" . }}-node
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Metrics endpoint for monitoring/prometheus
+  - from: []
+    ports:
+    - protocol: TCP
+      port: 15014
+  # Readiness probe endpoint
+  - from: []
+    ports:
+    - protocol: TCP
+      port: 8000
+  egress:
+  # Allow DNS resolution and access to Kubernetes API server.
+  # IP/Port of the API server is heavily dependant on k8s distribution, so we allow all egress for now.
+  - {}
+{{- end }}

--- a/releasenotes/notes/56877.yaml
+++ b/releasenotes/notes/56877.yaml
@@ -7,8 +7,8 @@ issue:
 
 releaseNotes:
   - |
-    **Added** optional NetworkPolicy deployment for istiod
+    **Added** optional NetworkPolicy deployment for istiod and istio-cni
 
-    You can set `global.networkPolicy.enabled=true` to deploy a default NetworkPolicy for istiod.
-    We're planning to extend this to later also include NetworkPolicy for istio-cni, ztunnel and
+    You can set `global.networkPolicy.enabled=true` to deploy a default NetworkPolicy for istiod
+    and istio-cni. We're planning to extend this to later also include NetworkPolicy for ztunnel and
     gateways.


### PR DESCRIPTION
This is a basic NetworkPolicy for istio-cni. It will be installed if the previously-introduced global.networkPolicy.enabled flag is set to `true`.
