### PR TITLE
manifests: fix NetworkPolicy creation

### DIFF
--- a/manifests/charts/istio-cni/templates/networkpolicy.yaml
+++ b/manifests/charts/istio-cni/templates/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.networkPolicy).enabled }}
+{{- if (.Values.global.networkPolicy).enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -134,6 +134,10 @@ _internal_defaults_do_not_set:
 
     logAsJson: false
 
+    # When enabled, default NetworkPolicy resources will be created
+    networkPolicy:
+      enabled: false
+
     # ImagePullSecrets for all ServiceAccount, list of secrets in the same namespace
     # to use for pulling any images in pods that reference this ServiceAccount.
     # For components that don't use ServiceAccounts (i.e. grafana, servicegraph, tracing)

--- a/manifests/charts/istio-control/istio-discovery/templates/networkpolicy.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.networkPolicy).enabled }}
+{{- if (.Values.global.networkPolicy).enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -276,7 +276,7 @@ _internal_defaults_do_not_set:
     logging:
       level: "default:info"
 
-    # When enabled, a default NetworkPolicy for istiod will be created
+    # When enabled, default NetworkPolicy resources will be created
     networkPolicy:
       enabled: false
 

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -576,6 +576,12 @@ func TestManifestGeneratePilot(t *testing.T) {
 			fileSelect:  []string{"templates/deployment.yaml"},
 			chartSource: liveCharts,
 		},
+		{
+			desc:        "networkpolicy_enabled",
+			diffSelect:  "NetworkPolicy:*:istiod",
+			fileSelect:  []string{"templates/networkpolicy.yaml"},
+			chartSource: liveCharts,
+		},
 	})
 }
 

--- a/operator/cmd/mesh/testdata/manifest-generate/input/networkpolicy_enabled.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input/networkpolicy_enabled.yaml
@@ -1,0 +1,10 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    global:
+      networkPolicy:
+        enabled: true
+  components:
+    pilot:
+      enabled: true

--- a/operator/cmd/mesh/testdata/manifest-generate/output/networkpolicy_enabled.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/networkpolicy_enabled.golden.yaml
@@ -1,0 +1,45 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app: istiod
+    app.kubernetes.io/instance: istio
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: istiod
+    app.kubernetes.io/part-of: istio
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: istiod-1.0.0
+    install.operator.istio.io/owning-resource: unknown
+    istio: pilot
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
+  name: istiod
+  namespace: istio-system
+spec:
+  egress:
+  - {}
+  ingress:
+  - from: []
+    ports:
+    - port: 15017
+      protocol: TCP
+  - from: []
+    ports:
+    - port: 15010
+      protocol: TCP
+    - port: 15011
+      protocol: TCP
+    - port: 15012
+      protocol: TCP
+    - port: 8080
+      protocol: TCP
+    - port: 15014
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: istiod
+      istio.io/rev: default
+  policyTypes:
+  - Ingress
+  - Egress


### PR DESCRIPTION
I had assumed that we're flattening the globals everywhere, but apparently we're only doing it for `ztunnel` and `gateway` charts.