### PR TITLE
Fix the proxy image to work with new proxy binary

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
     "name": "PROXY_REPO_SHA",
     "repoName": "proxy",
     "file": "",
-    "lastStableSHA": "a603f8b7ef9e956a01c03c499d6c59c393d7c257"
+    "lastStableSHA": "3dfa4b5d26fcf8078e92634b5dced26e520d81f1"
   },
   {
     "_comment": "",

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -1,4 +1,4 @@
-FROM rockylinux/rockylinux:9.4
+FROM quay.io/fedora/fedora:41
 
 WORKDIR /
 
@@ -6,11 +6,11 @@ ARG proxy_version
 ARG SIDECAR=envoy
 
 # hadolint ignore=DL3039,DL3041
-RUN dnf -y install iptables iproute openssl-3.0.7 libatomic && \
+RUN dnf -y install iptables iproute libatomic openssl-libs && \
     dnf -y clean all
 
-RUN ln -s /lib64/libssl.so.3.0.7 /lib64/libssl.so && \
-    ln -s /lib64/libcrypto.so.3.0.7 /lib64/libcrypto.so
+RUN ln -s /lib64/libssl.so.3 /lib64/libssl.so && \
+    ln -s /lib64/libcrypto.so.3 /lib64/libcrypto.so
 
 # Copy Envoy bootstrap templates used by pilot-agent
 COPY envoy_bootstrap.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json

--- a/pkg/test/echo/docker/Dockerfile.app_sidecar_centos_8
+++ b/pkg/test/echo/docker/Dockerfile.app_sidecar_centos_8
@@ -1,15 +1,32 @@
-ARG BASE_VERSION=latest
-ARG VM_IMAGE_NAME=rockylinux/rockylinux
-ARG VM_IMAGE_VERSION=9.4
-ARG ISTIO_BASE_REGISTRY=gcr.io/istio-release
+# ARG BASE_VERSION=latest
+# ARG VM_IMAGE_NAME=rockylinux/rockylinux
+# ARG VM_IMAGE_VERSION=9.4
+# ARG ISTIO_BASE_REGISTRY=gcr.io/istio-release
 
-FROM ${ISTIO_BASE_REGISTRY}/app_sidecar_base_${VM_IMAGE_NAME}_${VM_IMAGE_VERSION}:${BASE_VERSION}
+# FROM ${ISTIO_BASE_REGISTRY}/app_sidecar_base_${VM_IMAGE_NAME}_${VM_IMAGE_VERSION}:${BASE_VERSION}
 
-RUN yum install -y openssl-3.0.7 && \
-    yum clean all && rm -rf /var/cache/yum
+FROM quay.io/fedora/fedora:41
 
-RUN ln -s /lib64/libssl.so.3.0.7 /lib64/libssl.so && \
-    ln -s /lib64/libcrypto.so.3.0.7 /lib64/libcrypto.so
+# hadolint ignore=DL3005,DL3008,DL3033
+RUN yum install -y \
+    iptables \
+    iproute \
+    sudo \
+    nmap-ncat \
+    tcpdump \
+    procps \
+    conntrack \
+    net-tools \
+    ca-certificates \
+    hostname \
+    libatomic \
+    openssl-libs \
+    && update-ca-trust \
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
+RUN ln -s /lib64/libssl.so.3 /lib64/libssl.so && \
+    ln -s /lib64/libcrypto.so.3 /lib64/libcrypto.so
 
 # Install the certs.
 COPY certs/                           /var/lib/istio/


### PR DESCRIPTION
The envoy binary is built in a Fedora 41 container, and when it runs on Rockylinux we get errors like
```
envoy: /lib64/libm.so.6: version `GLIBC_2.38' not found (required by envoy)
```

So we need the sidecar image to also be based on Fedora.

Note that we already diverge a bit from upstream in this area.
