### PR TITLE
Specify Ztunnel NS in TestZtunnelConfig Ambient test

### DIFF
--- a/tests/integration/ambient/istioctl_test.go
+++ b/tests/integration/ambient/istioctl_test.go
@@ -40,8 +40,10 @@ func TestZtunnelConfig(t *testing.T) {
 			// Test setup
 			istioCtl := istioctl.NewOrFail(t, istioctl.Config{})
 			istioCfg := istio.DefaultConfigOrFail(t, t)
+			// Fetch the namespace of ztunnel resource
+			ztunnelNS := istioCfg.Values["pilot.trustedZtunnelNamespace"]
 			g := NewWithT(t)
-			ztunnelPods, err := kubetest.NewPodFetch(t.AllClusters()[0], istioCfg.SystemNamespace, "app=ztunnel")()
+			ztunnelPods, err := kubetest.NewPodFetch(t.AllClusters()[0], ztunnelNS, "app=ztunnel")()
 			assert.NoError(t, err)
 			podName, err := getPodName(ztunnelPods)
 			if err != nil {
@@ -49,7 +51,7 @@ func TestZtunnelConfig(t *testing.T) {
 			}
 
 			args := []string{
-				"zc", "all", podName, "-o", "json",
+				"zc", "all", podName, "--namespace", ztunnelNS, "-o", "json",
 			}
 			var zDumpAll configdump.ZtunnelDump
 			out, _ := istioCtl.InvokeOrFail(t, args)
@@ -63,7 +65,7 @@ func TestZtunnelConfig(t *testing.T) {
 
 			var zDump configdump.ZtunnelDump
 			args = []string{
-				"zc", "services", podName, "-o", "json",
+				"zc", "services", podName, "--namespace", ztunnelNS, "-o", "json",
 			}
 			out, _ = istioCtl.InvokeOrFail(t, args)
 			err = unmarshalListOrMap([]byte(out), &zDump.Services)
@@ -71,7 +73,7 @@ func TestZtunnelConfig(t *testing.T) {
 			g.Expect(zDump.Services).To(Not(BeNil()))
 
 			args = []string{
-				"zc", "workloads", podName, "-o", "json",
+				"zc", "workloads", podName, "--namespace", ztunnelNS, "-o", "json",
 			}
 			out, _ = istioCtl.InvokeOrFail(t, args)
 			err = unmarshalListOrMap([]byte(out), &zDump.Workloads)
@@ -79,7 +81,7 @@ func TestZtunnelConfig(t *testing.T) {
 			g.Expect(zDump.Workloads).To(Not(BeNil()))
 
 			args = []string{
-				"zc", "policies", podName, "-o", "json",
+				"zc", "policies", podName, "--namespace", ztunnelNS, "-o", "json",
 			}
 			out, _ = istioCtl.InvokeOrFail(t, args)
 			err = unmarshalListOrMap([]byte(out), &zDump.Policies)
@@ -87,7 +89,7 @@ func TestZtunnelConfig(t *testing.T) {
 			g.Expect(zDump.Policies).To(Not(BeNil()))
 
 			args = []string{
-				"zc", "certificates", podName, "-o", "json",
+				"zc", "certificates", podName, "--namespace", ztunnelNS, "-o", "json",
 			}
 			out, _ = istioCtl.InvokeOrFail(t, args)
 			err = unmarshalListOrMap([]byte(out), &zDump.Certificates)


### PR DESCRIPTION
**Please provide a description of this PR:**
During deployment of Ambient mode, Ztunnel resource could be deployed to any namespace.
Define the ztunnel namespace during istioctl call.

The ztunnel namespace allocated according to the
"pilot.trustedZtunnelNamespace" helm parameter.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
