### PR TITLE
[Release 1.26] move mesh config values out of gateway manifests

### DIFF
--- a/prow/config/sail-operator/egress-gateway-values.yaml
+++ b/prow/config/sail-operator/egress-gateway-values.yaml
@@ -2,8 +2,5 @@ platform: openshift
 autoscaling:
   enabled: false
 
-meshConfig:
-  accessLogFile: /dev/stdout
-
 service:
   type: ClusterIP

--- a/prow/config/sail-operator/ingress-gateway-values.yaml
+++ b/prow/config/sail-operator/ingress-gateway-values.yaml
@@ -2,9 +2,6 @@ platform: openshift
 autoscaling:
   enabled: false
 
-meshConfig:
-  accessLogFile: /dev/stdout
-
 service:
   ports:
     - port: 15021


### PR DESCRIPTION
**Please provide a description of this PR:**
Recent Istio helm gateway PR [1] modified the schema of the gateway manifests values configuration.
Global level values are not longer accepted by helm when applying to the gateway charts.
As a result, Istio control ingress and egrees deployment by Sail Operator fails.

The "meshConfig" "accessLogFile" will be added to the sail operator converter script:
https://github.com/openshift-service-mesh/sail-operator/pull/484

[1] - https://github.com/istio/istio/pull/57457

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
