### PR TITLE
Do not use a default revision in gatewayinstance tests

### DIFF
--- a/tests/integration/pilot/gatewayinstance/main_test.go
+++ b/tests/integration/pilot/gatewayinstance/main_test.go
@@ -99,11 +99,12 @@ values:
 			cfg.Values["global.istioNamespace"] = meshInstanceNS.Name()
 			cfg.SystemNamespace = meshInstanceNS.Name()
 			cfg.ControlPlaneValues = fmt.Sprintf(`
-namespace: %s`, meshInstanceNS.Name())
+namespace: %s
+revision: mesh`, meshInstanceNS.Name())
 		})).
 		SetupParallel(
 			// application namespaces are labeled according to the required control plane ownership.
-			namespace.Setup(&echoNS, namespace.Config{Prefix: "echo1", Inject: true, Revision: "", Labels: nil}),
+			namespace.Setup(&echoNS, namespace.Config{Prefix: "echo1", Inject: true, Revision: "mesh", Labels: nil}),
 			namespace.Setup(&externalNS, namespace.Config{Prefix: "external", Inject: false})).
 		SetupParallel(
 			deployment.SetupSingleNamespace(&apps, deployment.Config{


### PR DESCRIPTION
The test setup was creating two revisions where one was called default. In Istio 1.27 (after https://github.com/istio/istio/pull/56004) it resulted in two conflicting default tags which caused the echo workloads to be injected by incorrect control plane (gateway) which fails as it's not using CNI.

TAG     REVISION NAMESPACES
default default  
default gateway

istio-revision-tag-default-gateway... MutatingWebhookConfiguration was created for gateway revision (gateway namespace)
istio-revision-tag-default-mesh... MutatingWebhookConfiguration was created for default revision (mesh namespace)

Having both control planes in one namespace would result only in one default tag as it would be named the same and installation of second control plane would overwrite the existing default tag.

The fix is using proper revision names so there is no conflict.

