### PR TITLE
[release-1.28] Add `--tls-min-version` flag to istiod

### DIFF
--- a/pilot/cmd/pilot-discovery/app/cmd.go
+++ b/pilot/cmd/pilot-discovery/app/cmd.go
@@ -181,6 +181,9 @@ func addFlags(c *cobra.Command) {
 			"If omitted, the default Go cipher suites will be used. \n"+
 			"Preferred values: "+strings.Join(secureTLSCipherNames(), ", ")+". \n"+
 			"Insecure values: "+strings.Join(insecureTLSCipherNames(), ", ")+".")
+	c.PersistentFlags().StringVar(&serverArgs.ServerOptions.TLSOptions.TLSMinVersion, "tls-min-version", bootstrap.TLSMinVersion1_2,
+		"Minimum TLS version for the istiod TLS server. "+
+			fmt.Sprintf("Only %s and %s are supported.", bootstrap.TLSMinVersion1_2, bootstrap.TLSMinVersion1_3))
 
 	c.PersistentFlags().Float32Var(&serverArgs.RegistryOptions.KubeOptions.KubernetesAPIQPS, "kubernetesApiQPS", 80.0,
 		"Maximum QPS when communicating with the kubernetes API")

--- a/pilot/cmd/pilot-discovery/app/options.go
+++ b/pilot/cmd/pilot-discovery/app/options.go
@@ -68,6 +68,10 @@ func validateFlags(serverArgs *bootstrap.PilotArgs) error {
 		return err
 	}
 
+	if _, err := bootstrap.TLSMinVersion(serverArgs.ServerOptions.TLSOptions.TLSMinVersion); err != nil {
+		return err
+	}
+
 	_, err := bootstrap.TLSCipherSuites(serverArgs.ServerOptions.TLSOptions.TLSCipherSuites)
 
 	// TODO: add validation for other flags

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -797,6 +797,9 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs, trustDomain string)
 		MinVersion:   tls.VersionTLS12,
 		CipherSuites: args.ServerOptions.TLSOptions.CipherSuites,
 	}
+	if args.ServerOptions.TLSOptions.MinVersion != 0 {
+		cfg.MinVersion = args.ServerOptions.TLSOptions.MinVersion
+	}
 	// Compliance for xDS server TLS.
 	sec_model.EnforceGoCompliance(cfg)
 

--- a/pilot/pkg/bootstrap/webhook.go
+++ b/pilot/pkg/bootstrap/webhook.go
@@ -56,6 +56,9 @@ func (s *Server) initSecureWebhookServer(args *PilotArgs) {
 		MinVersion:     tls.VersionTLS12,
 		CipherSuites:   args.ServerOptions.TLSOptions.CipherSuites,
 	}
+	if args.ServerOptions.TLSOptions.MinVersion != 0 {
+		tlsConfig.MinVersion = args.ServerOptions.TLSOptions.MinVersion
+	}
 	// Compliance for control plane validation and injection webhook server.
 	sec_model.EnforceGoCompliance(tlsConfig)
 

--- a/releasenotes/notes/tls-min-version-flag.yaml
+++ b/releasenotes/notes/tls-min-version-flag.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+
+issue:
+  - https://github.com/istio/istio/issues/58789
+  - 58789
+
+releaseNotes:
+- |
+  **Added** `--tls-min-version` flag to `pilot-discovery` to configure the minimum TLS version
+  for the istiod server and webhook. Supported values are `1.2` (default) and `1.3`.


### PR DESCRIPTION
**Please provide a description of this PR:**
Cherry pick of [this commit](https://github.com/openshift-service-mesh/istio/commit/783b5af4f359b35473a4b761f55911616cfacfd4) to the 1.28 branch. Needed for TLS profile requirements. Related to: https://github.com/istio-ecosystem/sail-operator/pull/1513

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
