### PR TITLE
[release-1.28] tests: customize app image in PQC tests

### DIFF
--- a/tests/integration/ambient/pqc/main_test.go
+++ b/tests/integration/ambient/pqc/main_test.go
@@ -65,6 +65,7 @@ func TestMain(m *testing.M) {
 		Setup(istio.Setup(&i, func(ctx resource.Context, cfg *istio.Config) {
 			ctx.Settings().Ambient = true
 			ctx.Settings().SkipVMs()
+			ctx.Settings().EchoImage = "quay.io/sail-dev/app:release-1.28"
 			if ctx.Settings().AmbientMultiNetwork {
 				cfg.DeployEastWestGW = true
 			} else {

--- a/tests/integration/security/pqc/main_test.go
+++ b/tests/integration/security/pqc/main_test.go
@@ -58,6 +58,7 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&i, func(ctx resource.Context, cfg *istio.Config) {
+			ctx.Settings().EchoImage = "quay.io/sail-dev/app:release-1.28"
 			cfg.ControlPlaneValues = `
 values:
   pilot:


### PR DESCRIPTION
Custom TLS settings for echo were not included in 1.28 and 1.29 upstream, so we can't rely on `docker.io/istio/app` image in PQC tests.

This change won't be needed in 1.30+.