### PR TITLE
[OSSM-12848] Fix pilot/gatewayinstance subsuite when sail operator is used

### DIFF
--- a/prow/setup/sail-operator-setup.sh
+++ b/prow/setup/sail-operator-setup.sh
@@ -89,6 +89,9 @@ ZTUNNEL="${PROW}/config/sail-operator/ztunnel.yaml"
 INGRESS_GATEWAY_VALUES="${PROW}/config/sail-operator/ingress-gateway-values.yaml"
 EGRESS_GATEWAY_VALUES="${PROW}/config/sail-operator/egress-gateway-values.yaml"
 
+# Skip installing gateways
+INSTALL_GATEWAYS="${INSTALL_GATEWAYS:="true"}"
+
 CONVERTER_ADDRESS="https://raw.githubusercontent.com/istio-ecosystem/sail-operator/$CONVERTER_BRANCH/tools/configuration-converter.sh"
 CONVERTER_SCRIPT=$(basename "$CONVERTER_ADDRESS")
 
@@ -203,9 +206,49 @@ function patch_config() {
     ' -i "$WORKDIR/$SAIL_IOP_FILE"
     echo "Configured pilot.env for QUIC tests."
   fi
+
+  if [[ "$WORKDIR" == *"gatewayinstance"* ]]; then
+    # There are two meshes in this test in different namespaces. Set namespace according to that
+    DESIRED_NAMESPACE="$(yq eval '.spec.namespace' "$IOP_FILE")"
+    yq eval ".spec.namespace = \"$DESIRED_NAMESPACE\"" -i "$WORKDIR/$SAIL_IOP_FILE"
+    # Set name of Istio according to the .spec.revision (converter uses `default` which is valid only for single mesh)
+    ORIGINAL_NAME="$(yq eval '.spec.revision' "$IOP_FILE")"
+    yq eval ".metadata.name = \"$ORIGINAL_NAME\"" -i "$WORKDIR/$SAIL_IOP_FILE"
+  
+    if [[ "$ORIGINAL_NAME" == *"mesh"* ]] ; then
+      # since mesh is in different namespace as istio-system, change NAMESPACE for ingress/egress deployment below
+      INSTALL_GATEWAYS=true
+      NAMESPACE="${DESIRED_NAMESPACE}"
+      echo "Override istio-system NAMESPACE to $NAMESPACE for pilot/gatewayinstance istio control plane"
+      # we must limit only specific ns via discovery selectors
+      yq eval '.spec.values.meshConfig.discoverySelectors = [{"matchLabels": {"istio-instance": "mesh"}}]' -i "$WORKDIR/$SAIL_IOP_FILE"
+    else
+      # we don't want gateways in namespace where gateway mesh is
+      INSTALL_GATEWAYS=false
+      # we must limit only specific ns via discovery selectors
+      yq eval '.spec.values.meshConfig.discoverySelectors = [{"matchLabels": {"istio-instance": "gateway"}}]' -i "$WORKDIR/$SAIL_IOP_FILE"
+    fi
+  fi
 }
 
 function patch_gateway_config() {
+  if [[ "$WORKDIR" == *"gatewayinstance"* ]]; then
+    # mesh has different name. Remove `sidecar.istio.io/inject`` and add `istio.io/rev: mesh`` label/annotation
+    yq eval '
+      del(.spec.template.metadata.annotations["sidecar.istio.io/inject"]) |
+      del(.spec.template.metadata.labels["sidecar.istio.io/inject"]) |
+      .spec.template.metadata.annotations["istio.io/rev"] = "mesh" |
+      .spec.template.metadata.labels["istio.io/rev"] = "mesh"
+    ' -i "${WORKDIR}/istio-egressgateway.yaml"
+
+    yq eval '
+      del(.spec.template.metadata.annotations["sidecar.istio.io/inject"]) |
+      del(.spec.template.metadata.labels["sidecar.istio.io/inject"]) |
+      .spec.template.metadata.annotations["istio.io/rev"] = "mesh" |
+      .spec.template.metadata.labels["istio.io/rev"] = "mesh"
+    ' -i "${WORKDIR}/istio-ingressgateway.yaml"
+  fi
+
   # Adds gateway-specific configurations based on test requirements
   if [[ "$WORKDIR" == *"filebased-tls-origination"* ]]; then
     # Add volume and volumeMount for egress gateway TLS origination tests
@@ -311,7 +354,9 @@ if [ "$1" = "install" ]; then
     install_ztunnel || { echo "Failed to install ZTunnel"; exit 1; }
   fi
   install_istio || { echo "Failed to install Istio"; exit 1; }
-  install_gateways || { echo "Failed to install gateways"; exit 1; }
+  if [ "$INSTALL_GATEWAYS" == "true" ]; then
+    install_gateways || { echo "Failed to install gateways"; exit 1; }
+  fi
 elif [ "$1" = "cleanup" ]; then
   if [ "$SKIP_CLEANUP" = "true" ]; then
     echo "Skipping cleanup because SKIP_CLEANUP is set to true."

--- a/tests/integration/pilot/gatewayinstance/main_test.go
+++ b/tests/integration/pilot/gatewayinstance/main_test.go
@@ -104,8 +104,8 @@ revision: mesh`, meshInstanceNS.Name())
 		})).
 		SetupParallel(
 			// application namespaces are labeled according to the required control plane ownership.
-			namespace.Setup(&echoNS, namespace.Config{Prefix: "echo1", Inject: true, Revision: "mesh", Labels: nil}),
-			namespace.Setup(&externalNS, namespace.Config{Prefix: "external", Inject: false})).
+			namespace.Setup(&echoNS, namespace.Config{Prefix: "echo1", Inject: true, Revision: "mesh", Labels: map[string]string{"istio-instance": "mesh"}}),
+			namespace.Setup(&externalNS, namespace.Config{Prefix: "external", Inject: false, Labels: map[string]string{"istio-instance": "gateway"}})).
 		SetupParallel(
 			deployment.SetupSingleNamespace(&apps, deployment.Config{
 				Namespaces: []namespace.Getter{


### PR DESCRIPTION
Fix pilot/gatewayinstance when sail operator is used as external control plane installer
 ` --istio.test.kube.controlPlaneInstaller=./prow/setup/sail-operator-setup.sh` 
 
 The `gatewayinstance`:
- creates 2 different control planes (`mesh` and `gateway`) with different namespace as istio-system, so script must be updated to set correct namespace in sail-iop.yaml
- creates 2 different control planes (`mesh` and `gateway`) with different name as default, so script must be updated to set correct name in sail-iop.yaml
- `mesh` should have ingress/egress, `gateway` should not
  - since there are 2 control planes, the `sidecar.istio.io/inject` label/annotation must be changed to the `istio.io/rev`
- to correctly test ns boundaries, the discovery selector must be set in sail-iop.yaml 


 
 
**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

