### PR TITLE
Adapt test suite on OSSM 3.3+ proxy key validation on FIPS

### DIFF
--- a/pkg/test/framework/config.go
+++ b/pkg/test/framework/config.go
@@ -63,28 +63,29 @@ var GlobalYAMLWrites = atomic.NewUint64(0)
 // When DestinationRule for the whole mesh is applied, the proxy can validate 400+ keys, which can take ~1-2minutes.
 // Tests need to wait until the proxy is ready again.
 // After each creation/deletion of DestinationRule, we need to wait till proxy is updated.
-// istio-ingress proxy takes the longest according to observation, so only those pods are checked.
+// istio-ingress proxy and sidecar demo app take the longest according to observation, so only those pods are checked.
 func sleepIfDestinationRuleOnFips(ctx resource.Context, yamlFiles []string, operation string) {
 	for _, yamlFile := range yamlFiles {
 		content, err := os.ReadFile(yamlFile)
 		if err == nil && ctx.Settings().Fips && strings.Contains(string(content), "kind: DestinationRule") {
 			scopes.Framework.Infof("DestinationRule %s was %s, checking if istio-ingress proxy is ready", yamlFile, operation)
-			checkIngressProxyReady(ctx)
+			checkIngressProxyReady(ctx, "istio=ingressgateway")
+			checkIngressProxyReady(ctx, "app=sidecar")
 			return
 		}
 	}
 }
 
-// The function gets ingress gateway pods from the clusters and checks if the proxies return configuration via pod exec
+// The function gets pods according to label selector from the clusters and checks if the proxies return configuration via pod exec
 // if yes, the proxy is considered as ready
 // if not (timeouted after 1 minute), the proxy is considered as notReady/updating proxy config.
 // It tries 4 times (4 minutes max)
-func checkIngressProxyReady(ctx resource.Context) {
+func checkIngressProxyReady(ctx resource.Context, labelselecter string) {
 	scopes.Framework.Infof("Checking ingress gateway proxies are ready")
 	time.Sleep(10 * time.Second)
 	for _, cl := range ctx.Clusters() {
 		pods, err := cl.Kube().CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{
-			LabelSelector: "istio=ingressgateway",
+			LabelSelector: labelselecter,
 		})
 		if err != nil {
 			scopes.Framework.Warnf("failed getting ingress gateway pods for cluster %s: %v", cl.Name(), err)

--- a/pkg/test/framework/config.go
+++ b/pkg/test/framework/config.go
@@ -17,10 +17,13 @@ package framework
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
+	"time"
 
 	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/cluster"
@@ -55,6 +58,61 @@ func newConfigFactory(ctx resource.Context, clusters cluster.Clusters) config.Fa
 // GlobalYAMLWrites records how many YAMLs we have applied from all sources.
 // Note: go tests are distinct binaries per test suite, so this is the suite level number of calls
 var GlobalYAMLWrites = atomic.NewUint64(0)
+
+// For OSSM3.3+ on FIPS, Proxy is validating all keys before applying the new TLS context to the config. It can take longer for certain situations, e.g.:
+// When DestinationRule for the whole mesh is applied, the proxy can validate 400+ keys, which can take ~1-2minutes.
+// Tests need to wait until the proxy is ready again.
+// After each creation/deletion of DestinationRule, we need to wait till proxy is updated.
+// istio-ingress proxy takes the longest according to observation, so only those pods are checked.
+func sleepIfDestinationRuleOnFips(ctx resource.Context, yamlFiles []string, operation string) {
+	for _, yamlFile := range yamlFiles {
+		content, err := os.ReadFile(yamlFile)
+		if err == nil && ctx.Settings().Fips && strings.Contains(string(content), "kind: DestinationRule") {
+			scopes.Framework.Infof("DestinationRule %s was %s, checking if istio-ingress proxy is ready", yamlFile, operation)
+			checkIngressProxyReady(ctx)
+			return
+		}
+	}
+}
+
+// The function gets ingress gateway pods from the clusters and checks if the proxies return configuration via pod exec
+// if yes, the proxy is considered as ready
+// if not (timeouted after 1 minute), the proxy is considered as notReady/updating proxy config.
+// It tries 4 times (4 minutes max)
+func checkIngressProxyReady(ctx resource.Context) {
+	scopes.Framework.Infof("Checking ingress gateway proxies are ready")
+	time.Sleep(10 * time.Second)
+	for _, cl := range ctx.Clusters() {
+		pods, err := cl.Kube().CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{
+			LabelSelector: "istio=ingressgateway",
+		})
+		if err != nil {
+			scopes.Framework.Warnf("failed getting ingress gateway pods for cluster %s: %v", cl.Name(), err)
+			continue
+		}
+		if len(pods.Items) == 0 {
+			scopes.Framework.Infof("no ingress gateway pods found for cluster %s", cl.Name())
+			continue
+		}
+		for _, pod := range pods.Items {
+			scopes.Framework.Infof("checking proxy status for pod %s/%s", pod.Namespace, pod.Name)
+			maxRetries := 4
+			for attempt := 1; attempt <= maxRetries; attempt++ {
+				_, _, err = cl.PodExec(pod.Name, pod.Namespace, "istio-proxy", "pilot-agent request GET config_dump")
+				if err == nil {
+					break
+				}
+				if attempt == maxRetries {
+					scopes.Framework.Errorf(
+						"failed getting proxy config for pod %s/%s after %d attempts: %v. The proxy is considered as not ready.",
+						pod.Namespace, pod.Name, maxRetries, err)
+				} else {
+					scopes.Framework.Infof("ingress gateway proxy is not ready, trying again... (attempt %d/%d)", attempt, maxRetries)
+				}
+			}
+		}
+	}
+}
 
 func (c *configFactory) New() config.Plan {
 	return &configPlan{
@@ -98,11 +156,13 @@ func (c *configFactory) applyYAML(cleanupStrategy cleanup.Strategy, ns string, y
 			if err := cl.ApplyYAMLFiles(ns, yamlFiles...); err != nil {
 				return fmt.Errorf("failed applying YAML files %v to ns %s in cluster %s: %v", yamlFiles, ns, cl.Name(), err)
 			}
+			sleepIfDestinationRuleOnFips(c.ctx, yamlFiles, "applied")
 			c.ctx.CleanupStrategy(cleanupStrategy, func() {
 				scopes.Framework.Debugf("Deleting from %s: %s", cl.StableName(), strings.Join(yamlFiles, ", "))
 				if err := cl.DeleteYAMLFiles(ns, yamlFiles...); err != nil {
 					scopes.Framework.Errorf("failed deleting YAML files %v from ns %s in cluster %s: %v", yamlFiles, ns, cl.Name(), err)
 				}
+				sleepIfDestinationRuleOnFips(c.ctx, yamlFiles, "deleted")
 			})
 			return nil
 		})

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -190,7 +190,7 @@ func init() {
 		"Indicate the use of ambient mesh.")
 
 	flag.BoolVar(&settingsFromCommandLine.Fips, "istio.test.fips", settingsFromCommandLine.Fips,
-		"Indicate the use of fips compient cluster.")
+		"Indicate the use of fips compliant cluster.")
 
 	flag.BoolVar(&settingsFromCommandLine.PeerMetadataDiscovery, "istio.test.peer_metadata_discovery", settingsFromCommandLine.PeerMetadataDiscovery,
 		"Force the use of peer metadata discovery fallback for metadata exchange")

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -189,6 +189,9 @@ func init() {
 	flag.BoolVar(&settingsFromCommandLine.Ambient, "istio.test.ambient", settingsFromCommandLine.Ambient,
 		"Indicate the use of ambient mesh.")
 
+	flag.BoolVar(&settingsFromCommandLine.Fips, "istio.test.fips", settingsFromCommandLine.Fips,
+		"Indicate the use of fips compient cluster.")
+
 	flag.BoolVar(&settingsFromCommandLine.PeerMetadataDiscovery, "istio.test.peer_metadata_discovery", settingsFromCommandLine.PeerMetadataDiscovery,
 		"Force the use of peer metadata discovery fallback for metadata exchange")
 

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -142,6 +142,9 @@ type Settings struct {
 	// Ambient mesh is being used
 	Ambient bool
 
+	// Cluster is fips complient
+	Fips bool
+
 	// Use ambient instead of sidecars
 	AmbientEverywhere bool
 

--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -50,6 +50,7 @@ CONTROL_PLANE_SOURCE="${CONTROL_PLANE_SOURCE:-"istio"}"
 INSTALL_SAIL_OPERATOR="${INSTALL_SAIL_OPERATOR:-"false"}"
 TRUSTED_ZTUNNEL_NAMESPACE="${TRUSTED_ZTUNNEL_NAMESPACE:-"istio-system"}"
 AMBIENT="${AMBIENT:="false"}"
+FIPS="${FIPS:="false"}"
 TEST_HUB="${TEST_HUB:="image-registry.openshift-image-registry.svc:5000/${NAMESPACE}"}"
 DEPLOY_GATEWAY_API="false"
 IBM="${IBM:-"false"}"
@@ -275,8 +276,12 @@ if [ "${CONTROL_PLANE_SOURCE}" == "sail" ]; then
             unset 'base_cmd[i]'
         fi
     done
-
-    base_cmd+=("-timeout=120m")
+    if [ "${FIPS}" == "true" ]; then
+        base_cmd+=("-timeout=240m")
+        base_cmd+=("--istio.test.fips")
+    else
+        base_cmd+=("-timeout=120m")
+    fi
 
     # Add sail operator setup script
     SAIL_SETUP_SCRIPT="${WD}/setup/sail-operator-setup.sh"

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -568,6 +568,7 @@ The test framework supports the following command-line flags:
 | --istio.test.skipVM                | bool | Skip all the VM related parts in all the tests. (default is "false").                                                                                         |
 | --istio.test.helmRepo              | string | Overwrite the default helm Repo used for the tests.                                                                                                           |
 | --istio.test.ambient               | bool | Indicate the use of ambient mesh.                                                                                                                             |
+| --istio.test.fips                  | bool | Indicate the cluster is fips compliant                                                                                                                        |
 | --istio.test.openshift             | bool | Set to `true` when running the tests in an OpenShift cluster, rather than in KinD.                                                                            |
 | --istio.test.stableNamespaces      | bool | Set to `true` to use stable namespaces for the test. Useful with nocleanup to develop tests                                                                   |
 | --istio.test.nativeNftables        | bool | Set to `true` to use native nftable rules instead of iptable rules                      |

--- a/tests/integration/ambient/pqc/main_test.go
+++ b/tests/integration/ambient/pqc/main_test.go
@@ -62,6 +62,9 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		Label(testlabel.CustomSetup).
+		SkipIf("PQC is not working on FIPS cluster due to X25519MLKEM", func(t resource.Context) bool {
+			return t.Settings().Fips
+		}).
 		Setup(istio.Setup(&i, func(ctx resource.Context, cfg *istio.Config) {
 			ctx.Settings().Ambient = true
 			ctx.Settings().SkipVMs()

--- a/tests/integration/security/cacert_rotation/main_test.go
+++ b/tests/integration/security/cacert_rotation/main_test.go
@@ -235,7 +235,17 @@ func getWorkloadCertLastUpdateTime(t framework.TestContext, i echo.Instance, ctl
 	podName := fmt.Sprintf("%s.%s", podID, i.NamespaceName())
 	out, errOut, err := ctl.Invoke([]string{"pc", "s", podName, "-o", "json"})
 	if err != nil || errOut != "" {
-		t.Errorf("failed to retrieve pod secret from %s, err: %v errOut: %s", podName, err, errOut)
+		// if FIPS, try again, since the proxy can be in the middle of updating config,
+		// and in that period, the proxy doesn't respond, and `istioctl pc` is timed out after 1 minute
+		if !t.Settings().Fips {
+			t.Errorf("failed to retrieve pod secret from %s, err: %v errOut: %s", podName, err, errOut)
+		}
+		t.Logf("failed to retrieve pod secret. Port-forward can timeouted when proxy updating its config. Try again after 30 seconds")
+		time.Sleep(30 * time.Second)
+		out, errOut, err = ctl.Invoke([]string{"pc", "s", podName, "-o", "json"})
+		if err != nil || errOut != "" {
+			t.Errorf("failed to retrieve pod secret from %s, err: %v errOut: %s", podName, err, errOut)
+		}
 	}
 
 	dump := &admin.SecretsConfigDump{}

--- a/tests/integration/security/pqc/main_test.go
+++ b/tests/integration/security/pqc/main_test.go
@@ -56,6 +56,9 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		Label(label.CustomSetup).
+		SkipIf("PQC is not working on FIPS cluster due to X25519MLKEM", func(t resource.Context) bool {
+			return t.Settings().Fips
+		}).
 		Setup(istio.Setup(&i, func(ctx resource.Context, cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
 values:


### PR DESCRIPTION
For OSSM 3.3+, [the proxy (envoy-openssl) validates all keys](https://github.com/envoyproxy/envoy-openssl/commit/ea6da0d2b986e76ecd250f6eb4be47517fcebc34) in the new TLS context (after DestinationRule is created/updated). When there are lots of keys, it can take 1-2minutes.
 
The test suite should be adapted to this situation to not continue until the proxy is ready. (otherwise, there will be random failures) 