### PR TITLE
[release-1.30] feat: add fips-140-3-redhat COMPLIANCE_POLICY

### DIFF
--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -210,7 +210,8 @@ func (e *envoy) Run(abort <-chan error) error {
 	/* #nosec */
 	cmd := exec.Command(e.BinaryPath, args...)
 	cmd.Env = os.Environ()
-	if common_features.CompliancePolicy == common_features.FIPS_140_2 {
+	if common_features.CompliancePolicy == common_features.FIPS_140_2 ||
+		common_features.CompliancePolicy == common_features.FIPS_140_3_REDHAT {
 		// Limit the TLSv1.2 ciphers in google_grpc client in Envoy to the compliant ciphers.
 		cmd.Env = append(cmd.Env,
 			"GRPC_SSL_CIPHER_SUITES=ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384")

--- a/pkg/features/security.go
+++ b/pkg/features/security.go
@@ -23,6 +23,10 @@ const (
 	// nolint: revive, stylecheck
 	FIPS_140_2 = "fips-140-2"
 
+	// FIPS_140_3_REDHAT compliance policy for Red Hat's OpenSSL-based Go runtime.
+	// nolint: revive, stylecheck
+	FIPS_140_3_REDHAT = "fips-140-3-redhat"
+
 	PQC = "pqc"
 )
 
@@ -36,6 +40,10 @@ settings, including in-mesh mTLS and external TLS. Valid values are:
 * 'fips-140-2' which enforces a version of the TLS protocol and a subset
 of cipher suites overriding any user preferences or defaults for all runtime
 components, including Envoy, gRPC Go SDK, and gRPC C++ SDK.
+* 'fips-140-3-redhat' which enforces FIPS 140-3 compliance for Red Hat's
+OpenSSL-based Go runtime. Supports TLS v1.2 and v1.3. Does not configure
+default ciphers in Go (Red Hat's OpenSSL-based Go uses its FIPS module).
+Filters Envoy cipher suites to only FIPS-approved ciphers.
 * 'pqc' which enforces post-quantum-safe key exchange X25519MLKEM768, TLS v1.3
 and cipher suites TLS_AES_128_GCM_SHA256 and TLS_AES_256_GCM_SHA384 overriding
 any user preferences or defaults for all runtime components, including Envoy,

--- a/pkg/model/fips.go
+++ b/pkg/model/fips.go
@@ -47,6 +47,14 @@ func index(ciphers []string) map[string]struct{} {
 
 var fipsCipherIndex = index(fipsCiphers)
 
+var fips3Curves = []string{
+	"P-256",
+	"P-384",
+	"P-521",
+}
+
+var fips3CurveIndex = index(fips3Curves)
+
 // EnforceGoCompliance limits the TLS settings to the compliant values.
 // This should be called as the last policy.
 func EnforceGoCompliance(ctx *gotls.Config) {
@@ -58,6 +66,12 @@ func EnforceGoCompliance(ctx *gotls.Config) {
 		ctx.MaxVersion = gotls.VersionTLS12
 		ctx.CipherSuites = fipsGoCiphers
 		ctx.CurvePreferences = []gotls.CurveID{gotls.CurveP256}
+		return
+	case common_features.FIPS_140_3_REDHAT:
+		// Red Hat's OpenSSL-based Go runtime uses its own FIPS module for cipher selection.
+		// We only enforce TLS version bounds; cipher suites and curves are left to the FIPS module.
+		ctx.MinVersion = gotls.VersionTLS12
+		ctx.MaxVersion = gotls.VersionTLS13
 		return
 	case common_features.PQC:
 		ctx.MinVersion = gotls.VersionTLS13
@@ -94,6 +108,33 @@ func EnforceCompliance(ctx *tls.CommonTlsContext) {
 		}
 		// Default (unset) is P-256
 		ctx.TlsParams.EcdhCurves = nil
+		return
+	case common_features.FIPS_140_3_REDHAT:
+		if ctx.TlsParams == nil {
+			ctx.TlsParams = &tls.TlsParameters{}
+		}
+		ctx.TlsParams.TlsMinimumProtocolVersion = tls.TlsParameters_TLSv1_2
+		ctx.TlsParams.TlsMaximumProtocolVersion = tls.TlsParameters_TLSv1_3
+		// Filter cipher suites to only FIPS-approved ciphers.
+		if len(ctx.TlsParams.CipherSuites) > 0 {
+			ciphers := []string{}
+			for _, cipher := range ctx.TlsParams.CipherSuites {
+				if _, ok := fipsCipherIndex[cipher]; ok {
+					ciphers = append(ciphers, cipher)
+				}
+			}
+			ctx.TlsParams.CipherSuites = ciphers
+		}
+		// Filter ECDH curves to only FIPS 140-3 approved curves (P-256, P-384, P-521).
+		if len(ctx.TlsParams.EcdhCurves) > 0 {
+			curves := []string{}
+			for _, curve := range ctx.TlsParams.EcdhCurves {
+				if _, ok := fips3CurveIndex[curve]; ok {
+					curves = append(curves, curve)
+				}
+			}
+			ctx.TlsParams.EcdhCurves = curves
+		}
 		return
 	case common_features.PQC:
 		if ctx.TlsParams == nil {


### PR DESCRIPTION
This COMPLIANCE_POLICY allows Istio to work in a FIPS-enabled OpenShift cluster. In such an environment, all components will already be using a FIPS-validated module for encryption, so not setting any cipher suites or curves is sufficient. For Envoy, we still need to filter out non-compliant ciphers and curves.
