### PR TITLE
  Remove unnecessary from: [] in NetworkPolicy templates (#59592)

### DIFF
--- a/manifests/charts/istio-cni/templates/networkpolicy.yaml
+++ b/manifests/charts/istio-cni/templates/networkpolicy.yaml
@@ -21,13 +21,11 @@ spec:
   - Egress
   ingress:
   # Metrics endpoint for monitoring/prometheus
-  - from: []
-    ports:
+  - ports:
     - protocol: TCP
       port: 15014
   # Readiness probe endpoint
-  - from: []
-    ports:
+  - ports:
     - protocol: TCP
       port: 8000
   egress:

--- a/manifests/charts/istio-control/istio-discovery/templates/networkpolicy.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/networkpolicy.yaml
@@ -23,13 +23,11 @@ spec:
   - Egress
   ingress:
   # Webhook from kube-apiserver
-  - from: []
-    ports:
+  - ports:
     - protocol: TCP
       port: 15017
   # xDS from potentially anywhere
-  - from: []
-    ports:
+  - ports:
     - protocol: TCP
       port: 15010
     - protocol: TCP

--- a/manifests/charts/ztunnel/templates/networkpolicy.yaml
+++ b/manifests/charts/ztunnel/templates/networkpolicy.yaml
@@ -21,42 +21,35 @@ spec:
   - Egress
   ingress:
   # Readiness probe
-  - from: []
-    ports:
+  - ports:
     - protocol: TCP
       port: 15021
   # Monitoring/prometheus
-  - from: []
-    ports:
+  - ports:
     - protocol: TCP
       port: 15020  # Metrics
   # Admin interface
-  - from: []
-    ports:
+  - ports:
     - protocol: TCP
       port: 15000  # Admin interface
   # HBONE traffic
-  - from: []
-    ports:
+  - ports:
     - protocol: TCP
       port: 15008
   # Outbound traffic endpoint
-  - from: []
-    ports:
+  - ports:
     - protocol: TCP
       port: 15001
   # Traffic endpoint for inbound plaintext
-  - from: []
-    ports:
+  - ports:
     - protocol: TCP
       port: 15006
   # DNS Captures
-  - from: [ ]
-    ports:
-      - protocol: TCP
-        port: 15053
-      - protocol: UDP
-        port: 15053
+  - ports:
+    - protocol: TCP
+      port: 15053
+    - protocol: UDP
+      port: 15053
   egress:
   # Allow all egress
   - {}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/networkpolicy_enabled.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/networkpolicy_enabled.golden.yaml
@@ -20,12 +20,10 @@ spec:
   egress:
   - {}
   ingress:
-  - from: []
-    ports:
+  - ports:
     - port: 15017
       protocol: TCP
-  - from: []
-    ports:
+  - ports:
     - port: 15010
       protocol: TCP
     - port: 15011

--- a/releasenotes/notes/np-reconcile.yaml
+++ b/releasenotes/notes/np-reconcile.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+
+releaseNotes:
+  - |
+    **Fixed** unnecessary Helm reconciliations caused by `from: []` in NetworkPolicy ingress rules.


### PR DESCRIPTION
Backport of upstream istio/istio#59592 to release-1.27
Removes unnecessary `from: []` in NetworkPolicy templates which causes helm reconciliation issues
Note: 3 gateway networkpolicy files don't exist in 1.27, so only istio-discovery, istio-cni, and ztunnel templates were updated