### PR TITLE
Add Sail config for TestCNINeverEnrollsPodsInExcludedNamespaces test

### DIFF
--- a/prow/setup/sail-operator-setup.sh
+++ b/prow/setup/sail-operator-setup.sh
@@ -130,6 +130,7 @@ function install_istio_cni(){
   if [ "$AMBIENT" == "true" ]; then
     yq -i '.spec.profile="ambient"' "$TMP_ISTIOCNI"
   fi
+  patch_istiocni_config
   oc apply -f "$TMP_ISTIOCNI"
   echo "istioCNI created."
 }
@@ -273,6 +274,16 @@ function patch_gateway_config() {
     ' -i "${WORKDIR}/istio-ingressgateway.yaml"
 
     echo "Added HTTP3/QUIC port configuration to ingress gateway."
+  fi
+}
+
+function patch_istiocni_config() {
+  # Config set for "TestCNINeverEnrollsPodsInExcludedNamespaces" ambient cni test.
+  # The "cni-excluded-ns" NS name hardcoded here, since it's being created after Istio
+  # deployment by Sail and as a result could not be fetched dynamically.
+  if [[ "$WORKDIR" == *"ambient-cni-"* ]]; then
+      yq -i '.spec.values.cni.excludeNamespaces = ["istio-system", "cni-excluded-ns"]' "$TMP_ISTIOCNI"
+      echo "Ambient CNI config applied"
   fi
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Add required configuration to Sail Operator for Ambient CNI TestCNINeverEnrollsPodsInExcludedNamespaces integration test.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

**Required PR Label:** Please add one of the following labels to this PR:

- `permanent-change`: For OSSM-specific changes that should be cherry-picked to all release branches
- `no-permanent-change`: For temporary changes that should NOT be cherry-picked to release branches
- `pending-upstream-sync`: For changes awaiting upstream synchronization (cherry-pick until synced from upstream)

This labeling helps release maintainers identify which changes to include in new release branches.
