### PR TITLE
Disable Ambient integ tests due to unsupported CRDs

### DIFF
--- a/prow/skip_tests/skip_tests_full.yaml
+++ b/prow/skip_tests/skip_tests_full.yaml
@@ -156,6 +156,12 @@ test_suites:
       - name: "TestWaypointAsEgressGateway/http_origination_route_with_BackendTLSPolicy"
         reason: "Disabling because it requires experimental CRDs(#72020)"
         skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestWaypoint/TLS_connection_with_PQC-compliant_settings_should_succeed"
+        reason: "Disabling because it required experimental CRDs"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestWaypoint/TLS_connection_originated_by_the_waypoint_should_succeed"
+        reason: "Disabling because it required experimental CRDs"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
       - name: "TestZtunnelCRL"
         reason: "The new TestZtunnelCRL test still does not have supported values within Sail Operator for the test. Would be enabled, once fixed.(#74391)"
         skip_in: ['downstream','midstream_sail']


### PR DESCRIPTION
**Please provide a description of this PR:**
Disable the following tests as they require the use of experimental CRDs.
- TestWaypoint/TLS_connection_with_PQC-compliant_settings_should_succeed
- TestWaypoint/TLS_connection_originated_by_the_waypoint_should_succeed

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

**Required PR Label:** Please add one of the following labels to this PR:

- `permanent-change`: For OSSM-specific changes that should be cherry-picked to all release branches
- `no-permanent-change`: For temporary changes that should NOT be cherry-picked to release branches
- `pending-upstream-sync`: For changes awaiting upstream synchronization (cherry-pick until synced from upstream)

This labeling helps release maintainers identify which changes to include in new release branches.
