### PR TITLE
Skip new unsupported ambient gw conformance tests

### DIFF
--- a/prow/skip_tests/skip_tests_full.yaml
+++ b/prow/skip_tests/skip_tests_full.yaml
@@ -107,6 +107,9 @@ test_suites:
       - name: "TestAuthz_MultipleCustomProviders_Overlapping"
         reason: "The tests modify its configuration during the execution, which is not supported right now by Sail Operator install flow. (#74327)"
         skip_in: ['downstream','midstream_sail']
+      - name: "TestSidecarMutualTlsOrigination/valid_crl"
+        reason:
+        skip_in: ['midstream_sail']
     skip_subsuites:
       - name: "external_ca"
         reason: ""
@@ -231,6 +234,42 @@ test_suites:
       - name: "TestGatewayConformance/eNamespaceNone"
         reason: ""
         skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/MeshHTTPRoute303Redirect"
+        reason: "The installed Gateway API CRDs are an older version that lacks support for newer v1.5.x features the tests expect."
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/MeshHTTPRoute308Redirect"
+        reason: "The installed Gateway API CRDs are an older version that lacks support for newer v1.5.x features the tests expect."
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/HTTPRoute303Redirect"
+        reason: "The installed Gateway API CRDs are an older version that lacks support for newer v1.5.x features the tests expect."
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/HTTPRoute307Redirect"
+        reason: "The installed Gateway API CRDs are an older version that lacks support for newer v1.5.x features the tests expect."
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/HTTPRoute308Redirect"
+        reason: "The installed Gateway API CRDs are an older version that lacks support for newer v1.5.x features the tests expect."
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/HTTPRouteCORS"
+        reason: "The installed Gateway API CRDs are an older version that lacks support for newer v1.5.x features the tests expect."
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/BackendTLSPolicy"
+        reason: "The installed Gateway API CRDs are an older version that lacks support for newer v1.5.x features the tests expect."
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "GatewayInvalidTLSBackendConfiguration"
+        reason: "The installed Gateway API CRDs are an older version that lacks support for newer v1.5.x features the tests expect."
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/BackendTLSPolicyObservedGenerationBump"
+        reason: "The installed Gateway API CRDs are an older version that lacks support for newer v1.5.x features the tests expect."
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "GatewayInvalidFrontendClientCertificateValidation"
+        reason: "The installed Gateway API CRDs are an older version that lacks support for newer v1.5.x features the tests expect."
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "GatewayFrontendClientCertificateValidation"
+        reason: "The installed Gateway API CRDs are an older version that lacks support for newer v1.5.x features the tests expect."
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "GatewayFrontendInvalidDefaultClientCertificateValidation"
+        reason: "The installed Gateway API CRDs are an older version that lacks support for newer v1.5.x features the tests expect."
+        skip_in: ['downstream','midstream_sail','midstream_helm']
     skip_subsuites: []
     run_tests_only: []
   telemetry:
@@ -264,6 +303,9 @@ test_suites:
         reason: ""
         skip_in: ['midstream_helm']
       - name: "TestZtunnelFromPreviousMinorRelease"
+        reason: ""
+        skip_in: ['midstream_helm']
+      - name: "TestInPlaceUpgradeWebhookFailurePolicy"
         reason: ""
         skip_in: ['midstream_helm']
     skip_subsuites: []


### PR DESCRIPTION
**Please provide a description of this PR:**
The following new ambient gw conformance tests could not be executed on current OCP cluster, as the installed Gateway API CRDs are an older version that lacks support for newer v1.5.x features the tests expect.

The following tests are being disabled:
- TestGatewayConformance/MeshHTTPRoute303Redirect
- TestGatewayConformance/MeshHTTPRoute308Redirect
- TestGatewayConformance/HTTPRoute303Redirect
- TestGatewayConformance/HTTPRoute307Redirect
- TestGatewayConformance/HTTPRoute308Redirect
- TestGatewayConformance/HTTPRouteCORS
- TestGatewayConformance/BackendTLSPolicy
- GatewayInvalidTLSBackendConfiguration
- TestGatewayConformance/BackendTLSPolicyObservedGenerationBump
- GatewayInvalidFrontendClientCertificateValidation
- GatewayFrontendClientCertificateValidation
- GatewayFrontendInvalidDefaultClientCertificateValidation


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

**Required PR Label:** Please add one of the following labels to this PR:

- `permanent-change`: For OSSM-specific changes that should be cherry-picked to all release branches
- `no-permanent-change`: For temporary changes that should NOT be cherry-picked to release branches
- `pending-upstream-sync`: For changes awaiting upstream synchronization (cherry-pick until synced from upstream)

This labeling helps release maintainers identify which changes to include in new release branches.
