### PR TITLE
Deploy Sail Operator control plane based on branch

### DIFF
--- a/prow/setup/ocp_setup.sh
+++ b/prow/setup/ocp_setup.sh
@@ -32,6 +32,7 @@ WD=$(cd "$WD"; pwd)
 TIMEOUT=300
 export NAMESPACE="${NAMESPACE:-"istio-system"}"
 SAIL_REPO_URL="https://github.com/istio-ecosystem/sail-operator.git"
+SAIL_OPERATOR_BRANCH="${SAIL_OPERATOR_BRANCH:-}"  # Will be auto-detected if not set
 IBM="${IBM:-"false"}"
 
 function setup_internal_registry() {
@@ -245,16 +246,51 @@ function cleanup_sail_repo() {
     export TAG="$INITIAL_TAG"
 }
 
+# Detect and set the sail-operator branch based on current Istio branch
+function detect_sail_operator_branch() {
+  # Allow explicit override via environment variable
+  if [ -n "${SAIL_OPERATOR_BRANCH:-}" ]; then
+    echo "Using explicitly set SAIL_OPERATOR_BRANCH: ${SAIL_OPERATOR_BRANCH}"
+    return 0
+  fi
+
+  # Detect current Istio branch
+  local current_branch
+  current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")"
+
+  # Map Istio branch to sail-operator branch
+  if [[ "${current_branch}" == "main" ]] || [[ "${current_branch}" == "master" ]]; then
+    SAIL_OPERATOR_BRANCH="main"
+  elif [[ "${current_branch}" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
+    # Direct mapping: release-X.Y -> release-X.Y
+    SAIL_OPERATOR_BRANCH="${current_branch}"
+  else
+    # Fallback to main for unrecognized patterns (e.g., feature branches)
+    echo "Warning: Unrecognized branch pattern '${current_branch}', defaulting to sail-operator main branch"
+    SAIL_OPERATOR_BRANCH="main"
+  fi
+
+  export SAIL_OPERATOR_BRANCH
+  echo "Detected sail-operator branch: ${SAIL_OPERATOR_BRANCH} (from Istio branch: ${current_branch})"
+}
+
 function deploy_operator(){
+  # Detect appropriate sail-operator branch before cloning
+  detect_sail_operator_branch
+
+  # Save and unset env vars so sail-operator's make deploy uses its own defaults
   env_save
   unset HUB
   unset TAG
   unset NAMESPACE
-  git clone --depth 1 --branch main $SAIL_REPO_URL || { echo "Failed to clone sail-operator repo"; exit 1; }
+
+  git clone --depth 1 --branch "${SAIL_OPERATOR_BRANCH}" $SAIL_REPO_URL || { echo "Failed to clone sail-operator repo on branch ${SAIL_OPERATOR_BRANCH}"; exit 1; }
   cd sail-operator
   make deploy || { echo "sail-operator make deploy failed"; cleanup_sail_repo ; exit 1; }
   oc -n sail-operator wait --for=condition=Available deployment/sail-operator --timeout=240s || { echo "Failed to start sail-operator"; exit 1; }
+
+  # Restore original env vars for subsequent Istio operations
   cleanup_sail_repo
-  echo "Sail operator deployed"
+  echo "Sail operator deployed from branch: ${SAIL_OPERATOR_BRANCH}"
 
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
When Istio integ tests deploy Sail Operator control plane, the operator is being fetched and deployed from hardcoded "main" branch. When running Istio integration test from older branch, like "release-1.28" in prow environment, deployment of Sail Operator fails.

The failure happens since the recent changes made in "main" branch are not compatible with older branches.

Add logic to the Sail Operator deployment flow to identify the branch we're running in, and clone the sail repository from the equivalent branch.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

**Required PR Label:** Please add one of the following labels to this PR:

- `permanent-change`: For OSSM-specific changes that should be cherry-picked to all release branches
- `no-permanent-change`: For temporary changes that should NOT be cherry-picked to release branches
- `pending-upstream-sync`: For changes awaiting upstream synchronization (cherry-pick until synced from upstream)

This labeling helps release maintainers identify which changes to include in new release branches.
