### PR TITLE
Add terminationMessagePolicy helm field for pilot container (#60102)

### DIFF
--- a/manifests/charts/base/files/profile-platform-openshift.yaml
+++ b/manifests/charts/base/files/profile-platform-openshift.yaml
@@ -13,6 +13,7 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+  terminationMessagePolicy: FallbackToLogsOnError
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system

--- a/manifests/charts/default/files/profile-platform-openshift.yaml
+++ b/manifests/charts/default/files/profile-platform-openshift.yaml
@@ -13,6 +13,7 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+  terminationMessagePolicy: FallbackToLogsOnError
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system

--- a/manifests/charts/gateway/files/profile-platform-openshift.yaml
+++ b/manifests/charts/gateway/files/profile-platform-openshift.yaml
@@ -13,6 +13,7 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+  terminationMessagePolicy: FallbackToLogsOnError
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system

--- a/manifests/charts/gateways/istio-egress/files/profile-platform-openshift.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-platform-openshift.yaml
@@ -13,6 +13,7 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+  terminationMessagePolicy: FallbackToLogsOnError
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system

--- a/manifests/charts/gateways/istio-ingress/files/profile-platform-openshift.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-platform-openshift.yaml
@@ -13,6 +13,7 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+  terminationMessagePolicy: FallbackToLogsOnError
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system

--- a/manifests/charts/istio-cni/files/profile-platform-openshift.yaml
+++ b/manifests/charts/istio-cni/files/profile-platform-openshift.yaml
@@ -13,6 +13,7 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+  terminationMessagePolicy: FallbackToLogsOnError
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system

--- a/manifests/charts/istio-control/istio-discovery/files/profile-platform-openshift.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-platform-openshift.yaml
@@ -13,6 +13,7 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+  terminationMessagePolicy: FallbackToLogsOnError
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -103,6 +103,9 @@ spec:
 {{- if .Values.global.imagePullPolicy }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
 {{- end }}
+{{- if .Values.terminationMessagePolicy }}
+          terminationMessagePolicy: {{ .Values.terminationMessagePolicy }}
+{{- end }}
           args:
           - "discovery"
           - --monitoringAddr=:15014

--- a/manifests/charts/ztunnel/files/profile-platform-openshift.yaml
+++ b/manifests/charts/ztunnel/files/profile-platform-openshift.yaml
@@ -13,6 +13,7 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+  terminationMessagePolicy: FallbackToLogsOnError
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system

--- a/manifests/helm-profiles/platform-openshift.yaml
+++ b/manifests/helm-profiles/platform-openshift.yaml
@@ -9,6 +9,7 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+  terminationMessagePolicy: FallbackToLogsOnError
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system

--- a/releasenotes/notes/add-terminationmessagepolicy-field-to-istiod.yaml
+++ b/releasenotes/notes/add-terminationmessagepolicy-field-to-istiod.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+
+releaseNotes:
+  - |
+    **Added** `terminationMessagePolicy` helm field for the istiod (pilot) container, allowing configuration of how termination messages are populated.


### PR DESCRIPTION
Cherrypicking https://github.com/istio/istio/pull/60102 because we need to backport this to `release-1.30` branch

* Add terminationMessagePolicy helm field for pilot container



* Adding release note



---------

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

**Required PR Label:** Please add one of the following labels to this PR:

- `permanent-change`: For OSSM-specific changes that should be cherry-picked to all release branches
- `no-permanent-change`: For temporary changes that should NOT be cherry-picked to release branches
- `pending-upstream-sync`: For changes awaiting upstream synchronization (cherry-pick until synced from upstream)

This labeling helps release maintainers identify which changes to include in new release branches.
