### PR TITLE
Add missing Sail Operator test configs

### DIFF
--- a/prow/config/sail-operator/egress-gateway-values.yaml
+++ b/prow/config/sail-operator/egress-gateway-values.yaml
@@ -1,0 +1,6 @@
+platform: openshift
+autoscaling:
+  enabled: false
+
+service:
+  type: ClusterIP

--- a/prow/config/sail-operator/ingress-gateway-values.yaml
+++ b/prow/config/sail-operator/ingress-gateway-values.yaml
@@ -1,0 +1,29 @@
+platform: openshift
+autoscaling:
+  enabled: false
+
+service:
+  ports:
+    - port: 15021
+      targetPort: 15021
+      name: status-port
+    - port: 80
+      targetPort: 8080
+      name: http2
+    - port: 443
+      targetPort: 8443
+      name: https
+      # This is the port where sni routing happens
+    - port: 15443
+      targetPort: 15443
+      name: tls
+      ## Extra ports for testing
+    - port: 15012
+      targetPort: 15012
+      name: tls-istiod
+    - port: 15017
+      targetPort: 15017
+      name: tls-webhook
+    - port: 31400
+      targetPort: 31400
+      name: tcp

--- a/prow/config/sail-operator/istio-cni.yaml
+++ b/prow/config/sail-operator/istio-cni.yaml
@@ -1,0 +1,8 @@
+apiVersion: sailoperator.io/v1
+kind: IstioCNI
+metadata:
+  name: default
+spec:
+  namespace: ${ISTIOCNI_NAMESPACE}
+  version: ${ISTIO_VERSION}
+  profile: openshift

--- a/prow/config/sail-operator/validatingwebhook.yaml
+++ b/prow/config/sail-operator/validatingwebhook.yaml
@@ -1,0 +1,26 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: istiod-default-validator
+  labels:
+    app: istiod
+    release: istio
+webhooks:
+  - name: rev.validation.istio.io
+    clientConfig:
+      service:
+        name: istiod
+        namespace: istio-system
+        path: /validate
+      caBundle: <base64-encoded-CA-cert>
+    rules:
+      - apiGroups: ["security.istio.io", "networking.istio.io", "telemetry.istio.io", "extensions.istio.io"]
+        apiVersions: ["*"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["*"]
+        scope: "*"
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    timeoutSeconds: 10

--- a/prow/config/sail-operator/ztunnel.yaml
+++ b/prow/config/sail-operator/ztunnel.yaml
@@ -1,0 +1,7 @@
+apiVersion: sailoperator.io/v1
+kind: ZTunnel
+metadata:
+  name: default
+spec:
+  namespace: ${ZTUNNEL_NAMESPACE}
+  version: ${ISTIO_VERSION}

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -44,7 +44,14 @@ CLUSTER_NAME="${CLUSTER_NAME:-istio-testing}"
 CLUSTER_YAML="${CLUSTER_YAML:-prow/config/default.yaml}"
 
 export FAST_VM_BUILDS=true
-export ISTIO_DOCKER_BUILDER="${ISTIO_DOCKER_BUILDER:-docker}"
+export ISTIO_DOCKER_BUILDER="${ISTIO_DOCKER_BUILDER:-crane}"
+# DEVCONTAINER controls a set of features that allow this script to be run from
+# within a dev container using ghcr.io/devcontainers/features/docker-outside-of-docker
+export DEVCONTAINER="${DEVCONTAINER:-}"
+if [[ "${DEVCONTAINER}" ]]; then
+  export ISTIO_DOCKER_BUILDER=docker
+fi
+export NOMETALBINSTALL="${NOMETALBINSTALL:-}"
 
 PARAMS=()
 

--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -174,6 +174,28 @@ if [ "${TEST_HUB}" == "docker.io/istio" ]; then
     addGcrMirror
 fi
 
+# Check OCP version
+if ! OCP_VERSION_FULL=$(oc get clusterversion version -o jsonpath='{.status.desired.version}' 2>/dev/null); then
+    echo "Failed to detect OpenShift version. Are you connected to a cluster?"
+    exit 1
+fi
+OCP_VERSION_MINOR=$(echo "$OCP_VERSION_FULL" | cut -d. -f2)
+
+# Compare versions
+version_ge() {
+    # Returns 0 if $1 >= $2
+    [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
+}
+
+# Starting from OCP 4.19, Gateway API CRDs comes pre-installed and could not be modified by the user.
+# So for OCP version 4.19 and above, we're not deploying GW API CRDs.
+if version_ge "$OCP_VERSION_MINOR" "19"; then
+    echo "Openshift version 4.19 or above. Gateway API CRDs comes pre-installed with the cluster."
+else
+    echo "Openshift version below 4.19. Deploying Gateway API CRDs."
+    DEPLOY_GATEWAY_API="true"
+fi
+
 # Set up test command and parameters
 setup_junit_report() {
     export ISTIO_BIN="${GOPATH}/bin"
@@ -186,26 +208,30 @@ setup_junit_report() {
     echo "JUNIT_REPORT: ${JUNIT_REPORT}"
 }
 
-
 # Prepare go list expression for skipping suites
 if [[ -n "$SKIP_SUITE" ]]; then
-  mapfile -t TEST_PATHS < <(go list -tags=integ "./tests/integration/${TEST_SUITE}/..." | grep -vE "/(${SKIP_SUITE})$")
+  mapfile -t TEST_PATH < <(
+    go list -tags=integ "./tests/integration/${TEST_SUITE}/..." |
+    grep -vE "/(${SKIP_SUITE})$"
+  )
 else
-  TEST_PATHS=("./tests/integration/${TEST_SUITE}/...")
+  TEST_PATH=("./tests/integration/${TEST_SUITE}/...")
 fi
 
 # Build the base command and store it in an array
-base_cmd=("go" "test" "-p" "1" "-v" "-count=1" "-tags=integ" "-vet=off" "-timeout=60m" "${TEST_PATHS[@]}"
-          "--istio.test.ci"
-          "--istio.test.pullpolicy=IfNotPresent"
-          "--istio.test.work_dir=${ARTIFACTS_DIR}"
-          "--istio.test.skipTProxy=true"
-          "--istio.test.skipVM=true"
-          "--istio.test.istio.enableCNI=true"
-          "--istio.test.hub=${TEST_HUB}"
-          "--istio.test.tag=${TAG}"
-          "--istio.test.kube.deployGatewayAPI=${DEPLOY_GATEWAY_API}"
-          "--istio.test.openshift")
+base_cmd=(
+  "go" "test" "-p" "1" "-v" "-count=1" "-tags=integ" "-vet=off" "-timeout=60m"
+  "${TEST_PATH[@]}"
+  "--istio.test.ci"
+  "--istio.test.pullpolicy=IfNotPresent"
+  "--istio.test.work_dir=${ARTIFACTS_DIR}"
+  "--istio.test.skipVM=true"
+  "--istio.test.istio.enableCNI=true"
+  "--istio.test.hub=${TEST_HUB}"
+  "--istio.test.tag=${TAG}"
+  "--istio.test.kube.deployGatewayAPI=${DEPLOY_GATEWAY_API}"
+  "--istio.test.openshift"
+)
 
 helm_values="global.platform=openshift"
 
@@ -221,12 +247,16 @@ if [ "${TEST_SUITE}" == "pilot" ]; then
     # This flag we need to run the conformance test even if the CRDs are not matching with the desired ones in go.mod
     base_cmd+=("--istio.test.GatewayConformanceAllowCRDsMismatch=true")
     # Stops flaky runs in public clouds
-    base_cmd+=("--istio.test.gatewayConformance.maxTimeToConsistency=180s")
+    base_cmd+=("--istio.test.gatewayConformance.maxTimeToConsistency=300s")
 fi
 
 # If ambient mode executed, add "ambient" profile and args
-if [ "${AMBIENT}" == "true" ]; then
+if [[ "${AMBIENT}" == "true" || "${TEST_SUITE}" == *"ambient"* ]]; then
     base_cmd+=("--istio.test.ambient")
+    # This flag we need to run the conformance test even if the CRDs are not matching with the desired ones in go.mod
+    base_cmd+=("--istio.test.GatewayConformanceAllowCRDsMismatch=true")
+    # Stops flaky runs in public clouds
+    base_cmd+=("--istio.test.gatewayConformance.maxTimeToConsistency=300s")
     helm_values+=",pilot.trustedZtunnelNamespace=${TRUSTED_ZTUNNEL_NAMESPACE}"
     base_cmd+=("--istio.test.kube.ztunnelNamespace=${TRUSTED_ZTUNNEL_NAMESPACE}")
 
@@ -244,7 +274,7 @@ base_cmd+=("--istio.test.kube.helm.values=${helm_values}")
 
 # Append sail operator setup script to base command
 if [ "${CONTROL_PLANE_SOURCE}" == "sail" ]; then
-    # Remove timeout 60m 
+    # Remove timeout 60m
     for i in "${!base_cmd[@]}"; do
         if [[ "${base_cmd[$i]}" == "-timeout="* ]]; then
             unset 'base_cmd[i]'
@@ -304,7 +334,7 @@ elif [ "${TEST_OUTPUT_FORMAT}" == "gotestsum" ]; then
       --junitfile "${JUNIT_REPORT_DIR}/junit.xml" \
       --rerun-fails \
       --rerun-fails-max-failures=3 \
-      --packages "${TEST_PATHS[@]}" \
+      --packages "${TEST_PATH[@]}" \
       --debug \
       -- "${base_cmd[@]:5}"
       

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -118,7 +118,7 @@ function build_images() {
   targets="docker.pilot docker.proxyv2 docker.agentgateway "
 
   # use ubuntu:jammy to test vms by default
-  nonDistrolessTargets="docker.app docker.app_sidecar_rockylinux_9 docker.ext-authz "
+  nonDistrolessTargets="docker.app docker.app_sidecar_ubuntu_noble docker.ext-authz "
   if [[ "${JOB_TYPE:-presubmit}" == "postsubmit" ]]; then
     # We run tests across all VM types only in postsubmit
     nonDistrolessTargets+="docker.app_sidecar_ubuntu_bionic docker.app_sidecar_debian_12 docker.app_sidecar_rockylinux_9 "

--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -109,3 +109,4 @@ if [[ -z "${DRY_RUN:-}" ]]; then
     --gcsbucket "${GCS_BUCKET}" --gcsaliases "${TAG},${NEXT_VERSION}-dev" \
     --dockerhub "gcr.io/istio-testing" --helmhub "${HELM_HUB}" --dockertags "${TAG},${VERSION},${NEXT_VERSION}-dev"
 fi
+

--- a/prow/setup/sail-operator-setup.sh
+++ b/prow/setup/sail-operator-setup.sh
@@ -32,6 +32,8 @@ set -u
 set -x
 # fail if any command in the pipeline fails
 set -o pipefail
+# Show logs on error
+trap 'echo "❌ Script failed. Dumping log:"; echo "--------------------------------"; cat "$LOG_FILE"; echo "--------------------------------"; exit 1' ERR
 
 SKIP_CLEANUP="${SKIP_CLEANUP:-"false"}"
 
@@ -73,13 +75,32 @@ CONVERTER_BRANCH="${CONVERTER_BRANCH:-main}"
 
 # get istio version from versions.yaml
 VERSION_FILE="https://raw.githubusercontent.com/istio-ecosystem/sail-operator/$CONVERTER_BRANCH/pkg/istioversion/versions.yaml"
-if [ -z "${ISTIO_VERSION:-}" ]; then
-  ISTIO_VERSION="$(curl -s "$VERSION_FILE" | \
-    grep -E 'name: v[0-9]+\.[0-9]+-latest' | \
-    sed -E 's/.*(v[0-9]+\.[0-9]+)-latest.*/\1/' | \
-    sort -Vr | head -n1)-latest"
+if [ -n "${ISTIO_VERSION:-}" ]; then
+  echo "Using provided ISTIO_VERSION: $ISTIO_VERSION"
+else
+  if [ "$CONVERTER_BRANCH" = "main" ]; then
+    # If CONVERTER_BRANCH is main, change it to master and get the ref field
+    ISTIO_VERSION="$(curl -s "$VERSION_FILE" | \
+      grep -A 1 'name: master' | \
+      grep 'ref:' | \
+      sed -E 's/.*ref: (.*)/\1/' | \
+      head -n1)"
+  else
+    # Handle version stripping for CONVERTER_BRANCH like "release-1.28" -> "1.28"
+    if [[ "$CONVERTER_BRANCH" =~ ^release- ]]; then
+      # Strip "release-" prefix to get version (e.g., release-1.28 -> 1.28)
+      SEARCH_VERSION="${CONVERTER_BRANCH#release-}"
+    fi
+
+    # Look for the version with -latest suffix
+    ISTIO_VERSION="$(curl -s "$VERSION_FILE" | \
+      grep -E "name: v${SEARCH_VERSION}-latest" | \
+      sed -E "s/.*(v${SEARCH_VERSION}-latest).*/\1/" | \
+      head -n1)"
+  fi
+  echo "Using fetched ISTIO_VERSION: $ISTIO_VERSION"
 fi
-  
+
 NAMESPACE="${NAMESPACE:-istio-system}"
 ISTIOCNI_NAMESPACE="${ISTIOCNI_NAMESPACE:-istio-cni}"
 ZTUNNEL_NAMESPACE="${ZTUNNEL_NAMESPACE:-ztunnel}"
@@ -112,6 +133,7 @@ function install_istio_cni(){
   if [ "$AMBIENT" == "true" ]; then
     yq -i '.spec.profile="ambient"' "$TMP_ISTIOCNI"
   fi
+  patch_istiocni_config
   oc apply -f "$TMP_ISTIOCNI"
   echo "istioCNI created."
 }
@@ -159,7 +181,17 @@ function patch_config() {
     ' -i "$WORKDIR/$SAIL_IOP_FILE"
     echo "Configured tracing for Zipkin."
 
-  elif [[ "$WORKDIR" == *"-pilot-/"* ]]; then
+  elif [[ "$WORKDIR" == *"telemetry-tracing-otelcollector"* ]]; then
+  # Workaround until https://issues.redhat.com/browse/OSSM-10480 fixed
+    yq eval 'del(.spec.values.pilot.envVarFrom)' -i "$WORKDIR/$SAIL_IOP_FILE"
+    otel_cred="$(kubectl -n "$NAMESPACE" get secret otel-credentials -o jsonpath='{.data.bearer-token}' | base64 -d)"
+    CRED="$otel_cred" yq eval '
+      .spec.values.pilot.env.OTEL_GRPC_AUTHORIZATION = env(CRED) |
+      .spec.values.pilot.env.OTEL_GRPC_AUTHORIZATION style="double"
+    ' -i "$WORKDIR/$SAIL_IOP_FILE"
+    echo "Configured tracing for OtelCollector."
+
+  elif [[ "$WORKDIR" == *"pilot-"* ]]; then
     # Fix for TestTraffic/dns/a/ tests
     yq eval '
       .spec.values.meshConfig.defaultConfig.proxyMetadata.ISTIO_META_DNS_CAPTURE = "true"
@@ -169,6 +201,9 @@ function patch_config() {
 
   # Set Ambient config if set
   if [[ "$AMBIENT" == "true" ]]; then
+    yq eval '.spec.profile = "ambient"' -i "$WORKDIR/$SAIL_IOP_FILE"
+    yq eval ".spec.values.pilot.trustedZtunnelNamespace = \"$ZTUNNEL_NAMESPACE\"" -i "$WORKDIR/$SAIL_IOP_FILE"
+
     # Add discoverySelectors to match Helm behavior
     yq eval '.spec.values.meshConfig.discoverySelectors = [{"matchExpressions": [{"key": "istio.io/test-exclude-namespace", "operator": "DoesNotExist"}]}]' -i "$WORKDIR/$SAIL_IOP_FILE"
 
@@ -285,8 +320,18 @@ function patch_gateway_config() {
   fi
 }
 
+function patch_istiocni_config() {
+  # Config set for "TestCNINeverEnrollsPodsInExcludedNamespaces" ambient cni test.
+  # The "cni-excluded-ns" NS name hardcoded here, since it's being created after Istio
+  # deployment by Sail and as a result could not be fetched dynamically.
+  if [[ "$WORKDIR" == *"ambient-cni-"* ]]; then
+      yq -i '.spec.values.cni.excludeNamespaces = ["istio-system", "cni-excluded-ns"]' "$TMP_ISTIOCNI"
+      echo "Ambient CNI config applied"
+  fi
+}
+
 function patch_ztunnel_config() {
-  if [[ "$WORKDIR" == *"-ambient-pqc-"* ]]; then
+  if [[ "$WORKDIR" == *"ambient-pqc"* ]]; then
       yq -i '.spec.values.ztunnel.env.COMPLIANCE_POLICY="pqc"' "$TMP_ZTUNNEL"
   fi
 }
@@ -315,17 +360,28 @@ function cleanup_istio() {
   echo "Starting Istio cleanup..."
   TIMEOUT_DURATION="120s"
   
-  echo "Deleting Istio resources from namespace $ISTIOCNI_NAMESPACE..."
-  kubectl delete all --all -n "$ISTIOCNI_NAMESPACE" --wait=true --timeout=$TIMEOUT_DURATION || {
+  echo "Deleting IstioCNI resources from namespace $ISTIOCNI_NAMESPACE..."
+  kubectl delete istiocni --all -n "$ISTIOCNI_NAMESPACE" --wait=true --timeout=$TIMEOUT_DURATION || {
     echo "Normal delete failed for $ISTIOCNI_NAMESPACE or timed out, applying force delete..."
     kubectl delete all --all -n "$ISTIOCNI_NAMESPACE" --force --grace-period=0 --wait=true
   }
 
+  echo "Deleting ZTunnel resources from namespace $ZTUNNEL_NAMESPACE..."
+  kubectl delete ztunnel --all -n "$ZTUNNEL_NAMESPACE" --wait=true --timeout=$TIMEOUT_DURATION || {
+    echo "Normal delete failed for $ZTUNNEL_NAMESPACE or timed out, applying force delete..."
+    kubectl delete all --all -n "$ZTUNNEL_NAMESPACE" --force --grace-period=0 --wait=true
+  }
+
   echo "Deleting Istio resources from namespace $NAMESPACE..."
-  kubectl delete all --all -n "$NAMESPACE" --wait=true --timeout=$TIMEOUT_DURATION || {
+  kubectl delete istio --all -n "$NAMESPACE" --wait=true --timeout=$TIMEOUT_DURATION || {
     echo "Normal delete failed for $NAMESPACE or timed out, applying force delete..."
     kubectl delete all --all -n "$NAMESPACE" --force --grace-period=0 --wait=true
   }
+
+  echo "Delete Istio, IstioCNI and Ztunnel namespaces"
+  kubectl delete namespace "$ISTIOCNI_NAMESPACE" || true
+  kubectl delete namespace "$ZTUNNEL_NAMESPACE" || true
+  kubectl delete namespace "$NAMESPACE" || true
 
   echo "Cleanup completed successfully."
 }

--- a/prow/skip_tests/skip_tests_full.yaml
+++ b/prow/skip_tests/skip_tests_full.yaml
@@ -1,4 +1,4 @@
-# Test Configuration - Full Test Suite (release-1.28)
+# Test Configuration - Full Test Suite (release-1.30)
 # This file centralizes test run configuration for all runners (downstream, jenkins, etc.)
 # The data are used to run Istio Integration tests, to fill the command:
 # integ-suite-ocp.sh ${test_suite} ${skip_tests} ${skip_subsuites} ${run_tests_only}
@@ -244,3 +244,4 @@ test_suites:
         skip_in: ['midstream_helm']
     skip_subsuites: []
     run_tests_only: []
+


### PR DESCRIPTION
**Please provide a description of this PR:**
Add missing Sail Operator test configs for Istio integration tests

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

**Required PR Label:** Please add one of the following labels to this PR:

- `permanent-change`: For OSSM-specific changes that should be cherry-picked to all release branches
- `no-permanent-change`: For temporary changes that should NOT be cherry-picked to release branches
- `pending-upstream-sync`: For changes awaiting upstream synchronization (cherry-pick until synced from upstream)

This labeling helps release maintainers identify which changes to include in new release branches.
