### PR TITLE
Add Sail config for telemetry policy DynamicDNS test

### DIFF
--- a/prow/setup/sail-operator-setup.sh
+++ b/prow/setup/sail-operator-setup.sh
@@ -188,6 +188,15 @@ function patch_config() {
     ' -i "$WORKDIR/$SAIL_IOP_FILE"
     echo "Configured tracing for OtelCollector."
 
+  elif [[ "$WORKDIR" == *"telemetry-policy-dynamicdns"* ]]; then
+    yq eval '
+      .spec.values.meshConfig.enablePrometheusMerge = true |
+      .spec.values.meshConfig.outboundTrafficPolicy.mode = "ALLOW_ANY_DYNAMIC_DNS" |
+      .spec.values.meshConfig.outboundTrafficPolicy.tls.mode = "SIMPLE" |
+      .spec.values.meshConfig.outboundTrafficPolicy.tls.insecureSkipVerify = true
+    ' -i "$WORKDIR/$SAIL_IOP_FILE"
+    echo "Configured telemetry policy for DynamicDNS"
+
   elif [[ "$WORKDIR" == *"pilot-"* ]]; then
     # Fix for TestTraffic/dns/a/ tests
     yq eval '

--- a/prow/skip_tests/skip_tests_full.yaml
+++ b/prow/skip_tests/skip_tests_full.yaml
@@ -277,6 +277,9 @@ test_suites:
       - name: "TestDashboard/pilot-dashboard.json"
         reason: ""
         skip_in: ['downstream','midstream_sail']
+      - name: "TestAllowAnyDynamicDNSPolicy/http-via-dfp"
+        reason: "The tests changes its configuration during the execution. Sail does not support it. Disabling one of the tests"
+        skip_in: ['downstream','midstream_sail']
     skip_subsuites: []
     run_tests_only: []
   helm:


### PR DESCRIPTION
**Please provide a description of this PR:**
Add Sail Operator configuration for TestAllowAnyDynamicDNS telemetry policy test.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

**Required PR Label:** Please add one of the following labels to this PR:

- `permanent-change`: For OSSM-specific changes that should be cherry-picked to all release branches
- `no-permanent-change`: For temporary changes that should NOT be cherry-picked to release branches
- `pending-upstream-sync`: For changes awaiting upstream synchronization (cherry-pick until synced from upstream)

This labeling helps release maintainers identify which changes to include in new release branches.
