### PR TITLE
[release-1.30] Remove hardcoded echo image for pqc

### DIFF
--- a/tests/integration/ambient/pqc/main_test.go
+++ b/tests/integration/ambient/pqc/main_test.go
@@ -67,7 +67,6 @@ func TestMain(m *testing.M) {
 		Setup(istio.Setup(&i, func(ctx resource.Context, cfg *istio.Config) {
 			ctx.Settings().Ambient = true
 			ctx.Settings().SkipVMs()
-			ctx.Settings().EchoImage = "quay.io/sail-dev/app:release-1.28"
 			if ctx.Settings().AmbientMultiNetwork {
 				cfg.DeployEastWestGW = true
 			} else {

--- a/tests/integration/security/pqc/main_test.go
+++ b/tests/integration/security/pqc/main_test.go
@@ -60,7 +60,6 @@ func TestMain(m *testing.M) {
 			return t.Settings().Fips
 		}).
 		Setup(istio.Setup(&i, func(ctx resource.Context, cfg *istio.Config) {
-			ctx.Settings().EchoImage = "quay.io/sail-dev/app:release-1.28"
 			cfg.ControlPlaneValues = `
 values:
   pilot:


### PR DESCRIPTION
In `release-1.28` branch, we did a workaround for PQC tests since upstream 1.28 app image doesn't contain the required changes. No needed for 1.30+ versions.

Before merge, test PQC on all platforms:

- [x] x86_64
- [x] arm
- [x] IBM P
- [x] IBM Z