### PR TITLE
[release-1.24] pilot: config_dump of SDS corrupts XDS cache (#57592)

### DIFF
--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -638,6 +638,9 @@ func (s *DiscoveryServer) getConfigDumpByResourceType(conn *Connection, req *mod
 						continue
 					}
 					if secret.GetTlsCertificate() != nil {
+						// When utilizing XDS caching, the resource object is shared, so modifying this would modify the cached item
+						// Make a clone
+						rr = protomarshal.Clone(rr)
 						secret.GetTlsCertificate().PrivateKey = &core.DataSource{
 							Specifier: &core.DataSource_InlineBytes{
 								InlineBytes: []byte("[redacted]"),


### PR DESCRIPTION
This is a manual backport of https://github.com/istio/istio/commit/26f697a90a7a456b5814e2e0a8d9947e9de2b30c.