### PR TITLE
[release-1.28]prow: fix check_cluster_operators to survive transient oc errors and log unstable operators

### DIFF
--- a/prow/check-cluster-ready.sh
+++ b/prow/check-cluster-ready.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Copyright 2019 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Validates that all OpenShift cluster operators are stable before running tests.
+#
+# When kube-apiserver is rolling, it terminates oc exec WebSocket sessions. Running
+# this check *before* any oc exec call prevents those mid-session drops from being
+# mistaken for test failures.
+#
+# Usage:
+#   Standalone:  ./prow/check-cluster-ready.sh
+#   Sourced:     source ./prow/check-cluster-ready.sh   # provides check_cluster_operators()
+#
+# Environment:
+#   CLUSTER_OPERATOR_TIMEOUT  seconds to wait before giving up (default: 600)
+
+check_cluster_operators() {
+  if ! command -v jq &> /dev/null; then
+    echo "ERROR: jq is required for the cluster operator health check. Please install jq." >&2
+    return 1
+  fi
+
+  local timeout_seconds=${CLUSTER_OPERATOR_TIMEOUT:-600}
+  local end_time=$(( $(date +%s) + timeout_seconds ))
+  echo "Validating OpenShift cluster operators are stable (timeout: ${timeout_seconds}s)..."
+
+  while [ "$(date +%s)" -lt "$end_time" ]; do
+    local oc_output unstable_operators
+    if ! oc_output=$(oc get clusteroperator -o json 2>&1); then
+      echo "WARNING: 'oc get clusteroperator' failed (transient error?): ${oc_output}" >&2
+      sleep 15
+      continue
+    fi
+
+    if ! unstable_operators=$(jq '[.items[] | select(.status.conditions[] | (.type == "Available" and .status == "False") or (.type == "Progressing" and .status == "True") or (.type == "Degraded" and .status == "True"))] | length' <<< "${oc_output}"); then
+      echo "WARNING: jq failed to parse clusteroperator output" >&2
+      sleep 15
+      continue
+    fi
+
+    if [[ $unstable_operators -eq 0 ]]; then
+      echo "All cluster operators are stable."
+      return 0
+    fi
+
+    echo "WARNING: ${unstable_operators} unstable operator(s):" >&2
+    jq -r '.items[] | select(.status.conditions[] | (.type == "Available" and .status == "False") or (.type == "Progressing" and .status == "True") or (.type == "Degraded" and .status == "True")) | .metadata.name as $name | .status.conditions[] | select((.type == "Available" and .status == "False") or (.type == "Progressing" and .status == "True") or (.type == "Degraded" and .status == "True")) | "  \($name): \(.type)=\(.status) — \(.message)"' <<< "${oc_output}" >&2
+    sleep 15
+  done
+
+  echo "ERROR: Timeout reached. Not all cluster operators are stable." >&2
+  oc get clusteroperator >&2 || true
+  return 1
+}
+
+# When executed directly (not sourced), run the check and exit with its status.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  check_cluster_operators
+fi

--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -70,47 +70,8 @@ set -u
 # Print commands
 set -x
 
-check_cluster_operators() {
-  # Check if jq is installed
-  if ! command -v jq &> /dev/null; then
-    echo "ERROR: jq is required for the cluster operator health check. Please install jq."
-    exit 1
-  fi
-
-  local timeout_seconds=600 # 10 minutes
-  echo "Validating OpenShift cluster operators are stable..."
-  local end_time=$(( $(date +%s) + timeout_seconds ))
-
-  while [ "$(date +%s)" -lt $end_time ]; do
-    # This command uses jq to count operators that are not Available, or are Progressing, or are Degraded.
-    # A healthy cluster should have a count of 0.
-    local oc_output unstable_operators
-    if ! oc_output=$(oc get clusteroperator -o json 2>&1); then
-      echo "WARNING: 'oc get clusteroperator' failed (transient error?): ${oc_output}" >&2
-      sleep 15
-      continue
-    fi
-
-    if ! unstable_operators=$(jq '[.items[] | select(.status.conditions[] | (.type == "Available" and .status == "False") or (.type == "Progressing" and .status == "True") or (.type == "Degraded" and .status == "True"))] | length' <<< "${oc_output}"); then
-      echo "WARNING: jq failed to parse clusteroperator output" >&2
-      sleep 15
-      continue
-    fi
-
-    if [[ $unstable_operators -eq 0 ]]; then
-      echo "All cluster operators are stable."
-      return 0
-    fi
-
-    echo "WARNING: ${unstable_operators} unstable operator(s):" >&2
-    jq -r '.items[] | select(.status.conditions[] | (.type == "Available" and .status == "False") or (.type == "Progressing" and .status == "True") or (.type == "Degraded" and .status == "True")) | .metadata.name as $name | .status.conditions[] | select((.type == "Available" and .status == "False") or (.type == "Progressing" and .status == "True") or (.type == "Degraded" and .status == "True")) | "  \($name): \(.type)=\(.status) — \(.message)"' <<< "${oc_output}" >&2
-    sleep 15
-  done
-
-  echo "ERROR: Timeout reached. Not all cluster operators are stable."
-  oc get clusteroperator
-  exit 1
-}
+# shellcheck source=prow/check-cluster-ready.sh
+source "${ROOT}/prow/check-cluster-ready.sh"
 
 # shellcheck source=common/scripts/kind_provisioner.sh
 source "${ROOT}/prow/setup/ocp_setup.sh"

--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -84,15 +84,26 @@ check_cluster_operators() {
   while [ "$(date +%s)" -lt $end_time ]; do
     # This command uses jq to count operators that are not Available, or are Progressing, or are Degraded.
     # A healthy cluster should have a count of 0.
-    local unstable_operators
-    unstable_operators=$(oc get clusteroperator -o json | jq '[.items[] | select(.status.conditions[] | (.type == "Available" and .status == "False") or (.type == "Progressing" and .status == "True") or (.type == "Degraded" and .status == "True"))] | length')
+    local oc_output unstable_operators
+    if ! oc_output=$(oc get clusteroperator -o json 2>&1); then
+      echo "WARNING: 'oc get clusteroperator' failed (transient error?): ${oc_output}" >&2
+      sleep 15
+      continue
+    fi
+
+    if ! unstable_operators=$(jq '[.items[] | select(.status.conditions[] | (.type == "Available" and .status == "False") or (.type == "Progressing" and .status == "True") or (.type == "Degraded" and .status == "True"))] | length' <<< "${oc_output}"); then
+      echo "WARNING: jq failed to parse clusteroperator output" >&2
+      sleep 15
+      continue
+    fi
 
     if [[ $unstable_operators -eq 0 ]]; then
       echo "All cluster operators are stable."
       return 0
     fi
 
-    echo -n "."
+    echo "WARNING: ${unstable_operators} unstable operator(s):" >&2
+    jq -r '.items[] | select(.status.conditions[] | (.type == "Available" and .status == "False") or (.type == "Progressing" and .status == "True") or (.type == "Degraded" and .status == "True")) | .metadata.name as $name | .status.conditions[] | select((.type == "Available" and .status == "False") or (.type == "Progressing" and .status == "True") or (.type == "Degraded" and .status == "True")) | "  \($name): \(.type)=\(.status) — \(.message)"' <<< "${oc_output}" >&2
     sleep 15
   done
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Under set -o pipefail, a transient WebSocket error from the API server during `oc get clusteroperator -o json` causes the pipe to exit non-zero and kills the script immediately, bypassing the retry loop.

Separate the oc call from the jq pipe: capture output into a local variable, check its exit code explicitly, and continue the loop on failure. Apply the same guard to the jq step.

Also replace the silent dot-per-iteration with a per-retry warning that lists each unstable operator's name, condition type, and message, to make it easier to diagnose why the cluster is not converging.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

**Required PR Label:** Please add one of the following labels to this PR:

- `permanent-change`: For OSSM-specific changes that should be cherry-picked to all release branches
- `no-permanent-change`: For temporary changes that should NOT be cherry-picked to release branches
- `pending-upstream-sync`: For changes awaiting upstream synchronization (cherry-pick until synced from upstream)

This labeling helps release maintainers identify which changes to include in new release branches.
