### PR TITLE
Add "create-service-account" flag to CreateRemoteSecret test function

### DIFF
--- a/pkg/test/framework/components/istio/kube.go
+++ b/pkg/test/framework/components/istio/kube.go
@@ -735,6 +735,9 @@ func (i *istioImpl) CreateRemoteSecret(ctx resource.Context, c cluster.Cluster, 
 		"--namespace", i.cfg.SystemNamespace,
 		"--manifests", filepath.Join(testenv.IstioSrc, "manifests"),
 	}
+	if ctx.Settings().OpenShift {
+		istioctlCmd = append(istioctlCmd, "--create-service-account=false")
+	}
 	istioctlCmd = append(istioctlCmd, opts...)
 
 	scopes.Framework.Infof("Creating remote secret for cluster %s %v", c.Name(), istioctlCmd)


### PR DESCRIPTION
**Please provide a description of this PR:**
Add "--create-service-account=false" flag to "CreateRemoteSecret" test function, when executing on Openshift platform.
The change comes as followup to this commit, which requires to set that flag when running Openshift Service Mesh.
https://github.com/openshift-service-mesh/istio/commit/249514518d98119a959ba4ee2256be6f005d6696

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

**Required PR Label:** Please add one of the following labels to this PR:

- `permanent-change`: For OSSM-specific changes that should be cherry-picked to all release branches
- `no-permanent-change`: For temporary changes that should NOT be cherry-picked to release branches
- `pending-upstream-sync`: For changes awaiting upstream synchronization (cherry-pick until synced from upstream)

This labeling helps release maintainers identify which changes to include in new release branches.
