### PR TITLE
Reorganize the images used for the testing

### DIFF
--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -51,7 +51,7 @@ INSTALL_SAIL_OPERATOR="${INSTALL_SAIL_OPERATOR:-"false"}"
 TRUSTED_ZTUNNEL_NAMESPACE="${TRUSTED_ZTUNNEL_NAMESPACE:-"istio-system"}"
 AMBIENT="${AMBIENT:="false"}"
 FIPS="${FIPS:="false"}"
-TEST_HUB="${TEST_HUB:="image-registry.openshift-image-registry.svc:5000/${NAMESPACE}"}"
+TEST_HUB="${TEST_HUB:="image-registry.openshift-image-registry.svc:5000/istio-images"}"
 DEPLOY_GATEWAY_API="false"
 IBM="${IBM:-"false"}"
 

--- a/prow/setup/ocp_setup.sh
+++ b/prow/setup/ocp_setup.sh
@@ -31,6 +31,7 @@ WD=$(dirname "$0")
 WD=$(cd "$WD"; pwd)
 TIMEOUT=300
 export NAMESPACE="${NAMESPACE:-"istio-system"}"
+export IMAGE_NAMESPACE="${IMAGE_NAMESPACE:-"istio-images"}"
 SAIL_REPO_URL="https://github.com/istio-ecosystem/sail-operator.git"
 SAIL_OPERATOR_BRANCH="${SAIL_OPERATOR_BRANCH:-}"  # Will be auto-detected if not set
 IBM="${IBM:-"false"}"
@@ -53,13 +54,14 @@ function setup_internal_registry() {
 
   # Get the registry route
   URL=$(oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}')
-  # Hub will be equal to the route url/project-name(NameSpace) 
-  export HUB="${URL}/${NAMESPACE}"
+  # Hub will be equal to the route url/project-name(NameSpace)
+  export HUB="${URL}/${IMAGE_NAMESPACE}"
   echo "Internal registry URL: ${HUB}"
 
   # Create namespace from where the image are going to be pushed
   # This is needed because in the internal registry the images are stored in the namespace.
   # If the namespace already exist, it will not fail
+  oc create namespace "${IMAGE_NAMESPACE}" || true
   oc create namespace "${NAMESPACE}" || true
 
   deploy_rolebinding
@@ -87,7 +89,7 @@ items:
   kind: RoleBinding
   metadata:
     name: image-puller
-    namespace: '"$NAMESPACE"'
+    namespace: '"$IMAGE_NAMESPACE"'
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
@@ -103,7 +105,7 @@ items:
   kind: RoleBinding
   metadata:
     name: image-pusher
-    namespace: '"$NAMESPACE"'
+    namespace: '"$IMAGE_NAMESPACE"'
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole


### PR DESCRIPTION
**Please provide a description of this PR:**
Reorganize the images used for the testing
    
During the testing flow, created test images are being stored within "istio-system" namespace.
Since this namespace is used as a main NS of Istio deployment, cleanup of the deleted Istio and deletion of the "istio-system" namespace would lead to a deletion of the test images and test images pull RoleBindings.

Reorganize the images to a dedicated "istio-images" namespace, which independent of other istio components modifications and keep persistent over tests iterations.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

**Required PR Label:** Please add one of the following labels to this PR:

- `permanent-change`: For OSSM-specific changes that should be cherry-picked to all release branches
- `no-permanent-change`: For temporary changes that should NOT be cherry-picked to release branches
- `pending-upstream-sync`: For changes awaiting upstream synchronization (cherry-pick until synced from upstream)

This labeling helps release maintainers identify which changes to include in new release branches.
