### PR TITLE
[release-1.28] prow: enable GatewayConformance and add missing cherry pick

### DIFF
--- a/prow/check-cluster-ready.sh
+++ b/prow/check-cluster-ready.sh
@@ -33,7 +33,7 @@ check_cluster_operators() {
     return 1
   fi
 
-  local timeout_seconds=${CLUSTER_OPERATOR_TIMEOUT:-600}
+  local timeout_seconds=${CLUSTER_OPERATOR_TIMEOUT:-2700}
   local end_time=$(( $(date +%s) + timeout_seconds ))
   echo "Validating OpenShift cluster operators are stable (timeout: ${timeout_seconds}s)..."
 

--- a/prow/check-cluster-ready.sh
+++ b/prow/check-cluster-ready.sh
@@ -25,7 +25,7 @@
 #   Sourced:     source ./prow/check-cluster-ready.sh   # provides check_cluster_operators()
 #
 # Environment:
-#   CLUSTER_OPERATOR_TIMEOUT  seconds to wait before giving up (default: 2700)
+#   CLUSTER_OPERATOR_TIMEOUT  seconds to wait before giving up (default: 600)
 
 check_cluster_operators() {
   if ! command -v jq &> /dev/null; then
@@ -33,7 +33,7 @@ check_cluster_operators() {
     return 1
   fi
 
-  local timeout_seconds=${CLUSTER_OPERATOR_TIMEOUT:-2700}
+  local timeout_seconds=${CLUSTER_OPERATOR_TIMEOUT:-600}
   local end_time=$(( $(date +%s) + timeout_seconds ))
   echo "Validating OpenShift cluster operators are stable (timeout: ${timeout_seconds}s)..."
 

--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -70,6 +70,9 @@ set -u
 # Print commands
 set -x
 
+# shellcheck source=prow/check-cluster-ready.sh
+source "${ROOT}/prow/check-cluster-ready.sh"
+
 # shellcheck source=common/scripts/kind_provisioner.sh
 source "${ROOT}/prow/setup/ocp_setup.sh"
 
@@ -271,6 +274,10 @@ fi
 if [ -n "${SKIP_TESTS}" ]; then
     base_cmd+=("-skip" "${SKIP_TESTS}")
 fi
+
+# Re-check cluster operators after setup: the kube-apiserver can start rolling
+# again during image build/push, dropping the websocket when go test starts.
+check_cluster_operators
 
 # Execute the command and handle junit output
 if [ "${TEST_OUTPUT_FORMAT}" == "junit" ]; then

--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -70,11 +70,6 @@ set -u
 # Print commands
 set -x
 
-# ponytail: re-land #831 check with 45m timeout — OCP 4.22 kube-apiserver Progressing
-# exceeds 10m and kills oc exec websockets mid-test. Ceiling: CLUSTER_OPERATOR_TIMEOUT.
-# shellcheck source=prow/check-cluster-ready.sh
-source "${ROOT}/prow/check-cluster-ready.sh"
-
 # shellcheck source=common/scripts/kind_provisioner.sh
 source "${ROOT}/prow/setup/ocp_setup.sh"
 
@@ -276,9 +271,6 @@ fi
 if [ -n "${SKIP_TESTS}" ]; then
     base_cmd+=("-skip" "${SKIP_TESTS}")
 fi
-
-# Check cluster operators are stable before starting the tests
-check_cluster_operators
 
 # Execute the command and handle junit output
 if [ "${TEST_OUTPUT_FORMAT}" == "junit" ]; then

--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -221,12 +221,16 @@ if [ "${TEST_SUITE}" == "pilot" ]; then
     # This flag we need to run the conformance test even if the CRDs are not matching with the desired ones in go.mod
     base_cmd+=("--istio.test.GatewayConformanceAllowCRDsMismatch=true")
     # Stops flaky runs in public clouds
-    base_cmd+=("--istio.test.gatewayConformance.maxTimeToConsistency=180s")
+    base_cmd+=("--istio.test.gatewayConformance.maxTimeToConsistency=300s")
 fi
 
 # If ambient mode executed, add "ambient" profile and args
-if [ "${AMBIENT}" == "true" ]; then
+if [[ "${AMBIENT}" == "true" || "${TEST_SUITE}" == *"ambient"* ]]; then
     base_cmd+=("--istio.test.ambient")
+    # This flag we need to run the conformance test even if the CRDs are not matching with the desired ones in go.mod
+    base_cmd+=("--istio.test.GatewayConformanceAllowCRDsMismatch=true")
+    # Stops flaky runs in public clouds
+    base_cmd+=("--istio.test.gatewayConformance.maxTimeToConsistency=300s")
     helm_values+=",pilot.trustedZtunnelNamespace=${TRUSTED_ZTUNNEL_NAMESPACE}"
     base_cmd+=("--istio.test.kube.ztunnelNamespace=${TRUSTED_ZTUNNEL_NAMESPACE}")
 

--- a/prow/skip_tests/skip_tests_full.yaml
+++ b/prow/skip_tests/skip_tests_full.yaml
@@ -8,8 +8,11 @@ test_suites:
   pilot:
     skip_tests:
       - name: "TestGatewayConformance"
+        reason: "Needs to be patched to be able to execute. Patch is available on downstream."
+        skip_in: ['midstream_sail']
+      - name: "TestGatewayConformanceAgentgateway"
         reason: ""
-        skip_in: ['midstream_sail','midstream_helm']
+        skip_in: ['midstream_helm']
       - name: "TestGateway/managed-owner"
         reason: ""
         skip_in: ['downstream','midstream_sail','midstream_helm']
@@ -114,7 +117,7 @@ test_suites:
       - name: "TestCNIMisconfigHealsOnRestart"
         reason: ""
         skip_in: ['downstream','midstream_sail','midstream_helm']
-      - name: "TestGatewayConformance"
+      - name: "TestGatewayConformanceAgentgateway"
         reason: ""
         skip_in: ['downstream','midstream_sail','midstream_helm']
       - name: "TestAPIServer"
@@ -147,6 +150,84 @@ test_suites:
       - name: "TestZtunnelSecureMetrics"
         reason: ""
         skip_in: ['downstream','midstream_sail']
+      - name: "TestWaypointAsEgressGateway/http_origination_targetPort_with_BackendTLSPolicy"
+        reason: "Disabling because it requires experimental CRDs(#72020)"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestWaypointAsEgressGateway/http_origination_route_with_BackendTLSPolicy"
+        reason: "Disabling because it requires experimental CRDs(#72020)"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestWaypoint/TLS_connection_with_PQC-compliant_settings_should_succeed"
+        reason: "Disabling because it required experimental CRDs"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestWaypoint/TLS_connection_originated_by_the_waypoint_should_succeed"
+        reason: "Disabling because it required experimental CRDs"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestZtunnelCRL"
+        reason: "The new TestZtunnelCRL test still does not have supported values within Sail Operator for the test. Would be enabled, once fixed.(#74391)"
+        skip_in: ['downstream','midstream_sail']
+      - name: "TestGatewayConformance/TLSRouteInvalidReferenceGrant"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/TLSRouteSimpleSameNamespace"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/HTTPRouteCORSAllowCredentialsBehavior"
+        reason: "Not supported on CIO."
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/TLSRouteHostnameIntersection"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/TLSRouteInvalidBackendRefNonexistent"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/TLSRouteInvalidBackendRefUnknownKind"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/TLSRouteInvalidNoMatchingListenerHostname"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/TLSRouteInvalidNoMatchingListener"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/TLSRouteMixedTerminationSameNamespace"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/TLSRouteTerminateSimpleSameNamespace"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/BackendTLSPolicyInvalidCACertificateRef"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/BackendTLSPolicyInvalidKind"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/BackendTLSPolicySANValidation"
+        reason: "Disabling test which requires experimental CRDs"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/ListenerSetAllowedNamespaceNone"
+        reason: "ListenerSet CRDs is not installed by default"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/ListenerSetAllowedNamespaceSame"
+        reason: "ListenerSet CRDs is not installed by default"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/ListenerSetAllowedNamespaceSelector"
+        reason: "ListenerSet CRDs is not installed by default"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/ListenerSetAllowedRoutesNamespaces"
+        reason: "ListenerSet CRDs is not installed by default"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/ListenerSetAllowedRoutesSupportedKinds"
+        reason: "ListenerSet CRDs is not installed by default"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/ListenerSetDefaultNotAllowed"
+        reason: "ListenerSet CRDs is not installed by default"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/ListenerSetHTTPRouting"
+        reason: "ListenerSet CRDs is not installed by default"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/eNamespaceNone"
+        reason: ""
+        skip_in: ['downstream','midstream_sail','midstream_helm']
     skip_subsuites:
       - name: "pqc"
         reason: "This is a temporary change until we have ztunnel compiled with OpenSSL 3.5."


### PR DESCRIPTION
## Why

Integration test failures on release-1.28 had multiple root causes:

1. **WebSocket close 1006 mid-test**: The kube-apiserver can start rolling again during the image build/push phase (~6 min) inside the pod. When `go test` starts, the websocket drops immediately.

2. **Custom inline cluster-check approach inconsistent with other branches**: The branch had a bespoke `source check-cluster-ready.sh` + 45-minute timeout inside the script, diverging from the standard pattern used on master and other release branches.

3. **Missing gateway conformance improvements**: `maxTimeToConsistency=180s` and missing ambient test-suite trigger condition.

## Changes

- **`enable TestGatewayConformance for ambient and pilot midstream`** (cherry-pick of `57d8d2aa1c`): Bumps `maxTimeToConsistency` from 180s → 300s, extends ambient trigger to fire when `TEST_SUITE` contains `"ambient"`, and adds `GatewayConformanceAllowCRDsMismatch=true` + `maxTimeToConsistency=300s` to the ambient block.

- **Align cluster-ready check with standard approach**: Removes the bespoke inline `source` + `check_cluster_operators` call and resets `CLUSTER_OPERATOR_TIMEOUT` from 2700s to 600s, matching master and other release branches. PR #837 (automated cherry-pick that conflicted with this bespoke approach) was closed.

- **`prow: re-check cluster operators inside pod before running tests`** (cherry-pick of `b3f6415878`): Sources `check-cluster-ready.sh` and calls `check_cluster_operators` just before `go test`, after all setup is complete. Raises default timeout to 2700s to cover multi-node apiserver rolls. This replaces the bespoke inline approach with the standard pattern now consistent across all branches.