### PR TITLE
prow: re-check cluster operators inside pod before running tests

### DIFF
--- a/prow/check-cluster-ready.sh
+++ b/prow/check-cluster-ready.sh
@@ -33,7 +33,7 @@ check_cluster_operators() {
     return 1
   fi
 
-  local timeout_seconds=${CLUSTER_OPERATOR_TIMEOUT:-600}
+  local timeout_seconds=${CLUSTER_OPERATOR_TIMEOUT:-2700}
   local end_time=$(( $(date +%s) + timeout_seconds ))
   echo "Validating OpenShift cluster operators are stable (timeout: ${timeout_seconds}s)..."
 

--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -70,6 +70,9 @@ set -u
 # Print commands
 set -x
 
+# shellcheck source=prow/check-cluster-ready.sh
+source "${ROOT}/prow/check-cluster-ready.sh"
+
 # shellcheck source=common/scripts/kind_provisioner.sh
 source "${ROOT}/prow/setup/ocp_setup.sh"
 
@@ -271,6 +274,10 @@ fi
 if [ -n "${SKIP_TESTS}" ]; then
     base_cmd+=("-skip" "${SKIP_TESTS}")
 fi
+
+# Re-check cluster operators after setup: the kube-apiserver can start rolling
+# again during image build/push, dropping the websocket when go test starts.
+check_cluster_operators
 
 # Execute the command and handle junit output
 if [ "${TEST_OUTPUT_FORMAT}" == "junit" ]; then


### PR DESCRIPTION
The outer CI step calls `check-cluster-ready.sh` before opening `oc rsh`, but the kube-apiserver can start rolling again during the image build/push phase (~6 min inside the pod). When `go test` starts, the websocket drops immediately with close 1006.

## Changes

- **`prow/integ-suite-ocp.sh`**: source `check-cluster-ready.sh` and call `check_cluster_operators` just before the test command, after all setup is complete. This second check catches any apiserver roll that begins during image build/push.
- **`prow/check-cluster-ready.sh`**: raise default `CLUSTER_OPERATOR_TIMEOUT` from 600s to 2700s to cover multi-node apiserver rolls which can take 30+ minutes on OCP 4.22.