### PR TITLE
test: prepare ocp test runner to build and push to quay on midstream jobs

### DIFF
--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -102,6 +102,9 @@ build_images() {
 # Define the artifacts directory
 ARTIFACTS_DIR="${ARTIFACT_DIR:-"${WD}/artifacts"}"
 JUNIT_REPORT_DIR="${ARTIFACTS_DIR}/junit"
+# Create the junit output directory unconditionally so it is available even when
+# SKIP_SETUP=true (images pre-built by the servicemesh-istio-images-build CI step).
+mkdir -p "${JUNIT_REPORT_DIR}"
 
 # Install MetalLB if the flag is set
 if [ "${INSTALL_METALLB}" == "true" ]; then
@@ -111,9 +114,6 @@ if [ "${INSTALL_METALLB}" == "true" ]; then
 # Run the setup only if MetalLB is not being installed and setup is not skipped
 elif [ "${INSTALL_METALLB}" != "true" ] && [ "${SKIP_SETUP}" != "true" ]; then
     echo "Running full setup..."
-
-    # Ensure artifacts directory exists
-    mkdir -p "${JUNIT_REPORT_DIR}"
 
     # Setup the internal registry for the OCP cluster
     setup_internal_registry

--- a/prow/setup/ocp_setup.sh
+++ b/prow/setup/ocp_setup.sh
@@ -37,7 +37,15 @@ SAIL_OPERATOR_BRANCH="${SAIL_OPERATOR_BRANCH:-}"  # Will be auto-detected if not
 IBM="${IBM:-"false"}"
 
 function setup_internal_registry() {
-  # Validate that the internal registry is running in the OCP Cluster, configure the variable to be used in the make target. 
+  # If HUB is already set externally (e.g. quay.io/sail-dev/istio-testing from the
+  # images-build CI step), skip internal registry setup so the pre-set value is not
+  # overwritten with the OCP internal registry route URL.
+  if [ -n "${HUB:-}" ]; then
+    echo "HUB is already set to '${HUB}', skipping internal registry setup."
+    return 0
+  fi
+
+  # Validate that the internal registry is running in the OCP Cluster, configure the variable to be used in the make target.
   # If there is no internal registry, the test can't be executed targeting to the internal registry
 
   # Check if the registry pods are running

--- a/prow/setup/ocp_setup.sh
+++ b/prow/setup/ocp_setup.sh
@@ -37,11 +37,12 @@ SAIL_OPERATOR_BRANCH="${SAIL_OPERATOR_BRANCH:-}"  # Will be auto-detected if not
 IBM="${IBM:-"false"}"
 
 function setup_internal_registry() {
-  # If HUB is already set externally (e.g. quay.io/sail-dev/istio-testing from the
-  # images-build CI step), skip internal registry setup so the pre-set value is not
-  # overwritten with the OCP internal registry route URL.
-  if [ -n "${HUB:-}" ]; then
-    echo "HUB is already set to '${HUB}', skipping internal registry setup."
+  # If HUB is already set to a Quay registry (by the images-build CI step), skip
+  # internal registry setup so the pre-pushed images are not overwritten.
+  # Only skip for quay.io targets — other defaults (e.g. mirror.gcr.io/istio) must
+  # still be overwritten by the OCP internal registry route URL.
+  if [[ "${HUB:-}" == quay.io/* ]]; then
+    echo "HUB is already set to '${HUB}' (Quay registry), skipping internal registry setup."
     return 0
   fi
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Small changes to allow the integration test to build and push images to quay.io during a midstream test run against an OCP cluster. The main goal is to be able to separate the step for the test run and with this avoid the use of oc rsh that is causing us 1006 webSocket error 


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

**Required PR Label:** Please add one of the following labels to this PR:

- `permanent-change`: For OSSM-specific changes that should be cherry-picked to all release branches
- `no-permanent-change`: For temporary changes that should NOT be cherry-picked to release branches
- `pending-upstream-sync`: For changes awaiting upstream synchronization (cherry-pick until synced from upstream)

This labeling helps release maintainers identify which changes to include in new release branches.
