### PR TITLE
Fix variant build image

### DIFF
--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -89,13 +89,13 @@ build_images() {
     # use ubuntu:noble to test vms by default
     nonDistrolessTargets="docker.app docker.app_sidecar_ubuntu_noble docker.ext-authz docker.ztunnel "
 
-    if [[ "${VARIANT:-default}" == "distroless" ]]; then
-        echo "Building distroless images"
+    if [[ -z "${VARIANT:-}" || "${VARIANT}" == "distroless" ]]; then
+        echo "Building default and distroless images"
+        DOCKER_ARCHITECTURES="${arch}" DOCKER_BUILD_VARIANTS="default" DOCKER_TARGETS="${targets} ${nonDistrolessTargets}" make dockerx.pushx
         DOCKER_ARCHITECTURES="${arch}" DOCKER_BUILD_VARIANTS="distroless" DOCKER_TARGETS="${targets}" make dockerx.pushx
-        DOCKER_ARCHITECTURES="${arch}" DOCKER_BUILD_VARIANTS="default" DOCKER_TARGETS="${nonDistrolessTargets}" make dockerx.pushx
     else
         echo "Building default images"
-        DOCKER_ARCHITECTURES="${arch}"  DOCKER_BUILD_VARIANTS="${VARIANT:-default}" DOCKER_TARGETS="${targets} ${nonDistrolessTargets}" make dockerx.pushx
+        DOCKER_ARCHITECTURES="${arch}" DOCKER_BUILD_VARIANTS="${VARIANT}" DOCKER_TARGETS="${targets} ${nonDistrolessTargets}" make dockerx.pushx
     fi
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**
We get some errors here: https://github.com/openshift/release/pull/82416 when we split the build from the tst because VARIANT is not set before knowing which test you are going to run


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

**Required PR Label:** Please add one of the following labels to this PR:

- `permanent-change`: For OSSM-specific changes that should be cherry-picked to all release branches
- `no-permanent-change`: For temporary changes that should NOT be cherry-picked to release branches
- `pending-upstream-sync`: For changes awaiting upstream synchronization (cherry-pick until synced from upstream)

This labeling helps release maintainers identify which changes to include in new release branches.
