### PR TITLE
[release-1.28] test: prepare ocp test runner to build and push to quay on midstream jobs

### DIFF
--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -91,13 +91,13 @@ build_images() {
     # use ubuntu:noble to test vms by default
     nonDistrolessTargets="docker.app docker.app_sidecar_ubuntu_noble docker.ext-authz docker.ztunnel "
 
-    if [[ "${VARIANT:-default}" == "distroless" ]]; then
-        echo "Building distroless images"
+    if [[ -z "${VARIANT:-}" || "${VARIANT}" == "distroless" ]]; then
+        echo "Building default and distroless images"
+        DOCKER_ARCHITECTURES="${arch}" DOCKER_BUILD_VARIANTS="default" DOCKER_TARGETS="${targets} ${nonDistrolessTargets}" make dockerx.pushx
         DOCKER_ARCHITECTURES="${arch}" DOCKER_BUILD_VARIANTS="distroless" DOCKER_TARGETS="${targets}" make dockerx.pushx
-        DOCKER_ARCHITECTURES="${arch}" DOCKER_BUILD_VARIANTS="default" DOCKER_TARGETS="${nonDistrolessTargets}" make dockerx.pushx
     else
         echo "Building default images"
-        DOCKER_ARCHITECTURES="${arch}"  DOCKER_BUILD_VARIANTS="${VARIANT:-default}" DOCKER_TARGETS="${targets} ${nonDistrolessTargets}" make dockerx.pushx
+        DOCKER_ARCHITECTURES="${arch}" DOCKER_BUILD_VARIANTS="${VARIANT}" DOCKER_TARGETS="${targets} ${nonDistrolessTargets}" make dockerx.pushx
     fi
 }
 

--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -104,6 +104,9 @@ build_images() {
 # Define the artifacts directory
 ARTIFACTS_DIR="${ARTIFACT_DIR:-"${WD}/artifacts"}"
 JUNIT_REPORT_DIR="${ARTIFACTS_DIR}/junit"
+# Create the junit output directory unconditionally so it is available even when
+# SKIP_SETUP=true (images pre-built by the servicemesh-istio-images-build CI step).
+mkdir -p "${JUNIT_REPORT_DIR}"
 
 # Install MetalLB if the flag is set
 if [ "${INSTALL_METALLB}" == "true" ]; then
@@ -113,9 +116,6 @@ if [ "${INSTALL_METALLB}" == "true" ]; then
 # Run the setup only if MetalLB is not being installed and setup is not skipped
 elif [ "${INSTALL_METALLB}" != "true" ] && [ "${SKIP_SETUP}" != "true" ]; then
     echo "Running full setup..."
-
-    # Ensure artifacts directory exists
-    mkdir -p "${JUNIT_REPORT_DIR}"
 
     # Setup the internal registry for the OCP cluster
     setup_internal_registry

--- a/prow/setup/ocp_setup.sh
+++ b/prow/setup/ocp_setup.sh
@@ -37,7 +37,15 @@ SAIL_OPERATOR_BRANCH="${SAIL_OPERATOR_BRANCH:-}"  # Will be auto-detected if not
 IBM="${IBM:-"false"}"
 
 function setup_internal_registry() {
-  # Validate that the internal registry is running in the OCP Cluster, configure the variable to be used in the make target. 
+  # If HUB is already set externally (e.g. quay.io/sail-dev/istio-testing from the
+  # images-build CI step), skip internal registry setup so the pre-set value is not
+  # overwritten with the OCP internal registry route URL.
+  if [ -n "${HUB:-}" ]; then
+    echo "HUB is already set to '${HUB}', skipping internal registry setup."
+    return 0
+  fi
+
+  # Validate that the internal registry is running in the OCP Cluster, configure the variable to be used in the make target.
   # If there is no internal registry, the test can't be executed targeting to the internal registry
 
   # Check if the registry pods are running

--- a/prow/setup/ocp_setup.sh
+++ b/prow/setup/ocp_setup.sh
@@ -37,11 +37,12 @@ SAIL_OPERATOR_BRANCH="${SAIL_OPERATOR_BRANCH:-}"  # Will be auto-detected if not
 IBM="${IBM:-"false"}"
 
 function setup_internal_registry() {
-  # If HUB is already set externally (e.g. quay.io/sail-dev/istio-testing from the
-  # images-build CI step), skip internal registry setup so the pre-set value is not
-  # overwritten with the OCP internal registry route URL.
-  if [ -n "${HUB:-}" ]; then
-    echo "HUB is already set to '${HUB}', skipping internal registry setup."
+  # If HUB is already set to a Quay registry (by the images-build CI step), skip
+  # internal registry setup so the pre-pushed images are not overwritten.
+  # Only skip for quay.io targets — other defaults (e.g. mirror.gcr.io/istio) must
+  # still be overwritten by the OCP internal registry route URL.
+  if [[ "${HUB:-}" == quay.io/* ]]; then
+    echo "HUB is already set to '${HUB}' (Quay registry), skipping internal registry setup."
     return 0
   fi
 


### PR DESCRIPTION
Cherry-pick of #860 and bb9fadf556 onto release-1.28. Replaces #863 which could not be updated directly.