### PR TITLE
[do not merge!] Disable PILOT_ENABLE_ALPHA_GATEWAY_API

### DIFF
--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -205,7 +205,7 @@ base_cmd=(
   "--istio.test.openshift"
 )
 
-helm_values="global.platform=openshift"
+helm_values="global.platform=openshift,pilot.env.PILOT_ENABLE_ALPHA_GATEWAY_API=false"
 
 # IBM specific modifications
 if [ "${IBM}" == "true" ]; then

--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -213,9 +213,12 @@ if [ "${IBM}" == "true" ]; then
 fi
 
 # Gateway Conformance Test related modifications
-if [ "${TEST_SUITE}" == "pilot" ]; then
-    # Until OCP 4.19 default CRDs has https://github.com/kubernetes-sigs/gateway-api/pull/3389 we need following patch
-    git apply --verbose --reject --whitespace=fix --ignore-space-change ./prow/config/sail-operator/istio-gw-api-coredns-fix.patch
+if [ "${TEST_SUITE}" == "pilot" ] || [ "${TEST_SUITE}" == "ambient" ]; then
+    if [ "${TEST_SUITE}" == "pilot" ]; then
+        # Until OCP 4.19 default CRDs has https://github.com/kubernetes-sigs/gateway-api/pull/3389 we need following patch
+        # Patch targets tests/integration/pilot/gateway_conformance_test.go only.
+        git apply --verbose --reject --whitespace=fix --ignore-space-change ./prow/config/sail-operator/istio-gw-api-coredns-fix.patch
+    fi
     # This flag we need to run the conformance test even if the CRDs are not matching with the desired ones in go.mod
     base_cmd+=("--istio.test.GatewayConformanceAllowCRDsMismatch=true")
     # Stops flaky runs in public clouds

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -127,6 +127,9 @@ func TestGatewayConformance(t *testing.T) {
 				},
 				TimeoutConfig: ctx.Settings().GatewayConformanceTimeoutConfig,
 			}
+			if ctx.Settings().GatewayConformanceAllowCRDsMismatch {
+				opts.AllowCRDsMismatch = true
+			}
 
 			ctx.Cleanup(func() {
 				if !ctx.Failed() {


### PR DESCRIPTION
**Please provide a description of this PR:**
Testing disabling PILOT_ENABLE_ALPHA_GATEWAY_API https://github.com/openshift-cherrypick-robot/istio-1/blob/master/tests/integration/base.yaml#L23 since OCP platform doesn't allow enabling experimental CRDs. 

If tests pass, I will create the change to main. I am testing this on release-1.27 since there is an issue after upgrading to OCP 4.22 . So easy to verify that it works as expected