### PR TITLE
Disable PILOT_ENABLE_ALPHA_GATEWAY_API in testing via helm

### DIFF
--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -205,7 +205,8 @@ base_cmd=(
   "--istio.test.openshift"
 )
 
-helm_values="global.platform=openshift"
+# disable PILOT_ENABLE_ALPHA_GATEWAY_API env here https://github.com/istio/istio/blob/master/tests/integration/base.yaml#L23 since there is no way how to enable experimental gw api crds on OpenShift
+helm_values="global.platform=openshift,pilot.env.PILOT_ENABLE_ALPHA_GATEWAY_API=false"
 
 # IBM specific modifications
 if [ "${IBM}" == "true" ]; then


### PR DESCRIPTION
Enabling experimental GatewayAPI CRDs in pilot via `PILOT_ENABLE_ALPHA_GATEWAY_API` on the OpenShift platform results in an istiod runtime error.

This issue arises because setting this value to true causes istiod to expect experimental CRDs, whereas the version utilized by the OCP platform has already promoted those CRDs to General Availability (GA).

For instance, `release-1.27` expects Gateway CRDs API 1.3.0; however, OCP 4.22 features a newer version where the experimental `BackendTLSPolicy` from 1.3.0 has moved to GA. This mismatch triggers the following error in istiod:
```
2026-08-03T09:12:43.663260Z	error	watch error in cluster Kubernetes: failed to list *v1alpha3.BackendTLSPolicy: the server could not find the requested resource (get backendtlspolicies.gateway.networking.k8s.io)
```

This PR sets PILOT_ENABLE_ALPHA_GATEWAY_API to `false` to avoid this version mismatch again. Also, on the OCP platform, there is no way to enable the experimental (alpha) gateway api CRDs anyway. (So it is pointless to set that value to true )

===

Cherry-picks to older branches:

- https://github.com/openshift-service-mesh/istio/pull/873
- https://github.com/openshift-service-mesh/istio/pull/874
- https://github.com/openshift-service-mesh/istio/pull/875
- https://github.com/openshift-service-mesh/istio/pull/878

\+ missing upstream cherry-picks in older release branches:

- https://github.com/openshift-service-mesh/istio/pull/883
- https://github.com/openshift-service-mesh/istio/pull/882
- https://github.com/openshift-service-mesh/istio/pull/881
- https://github.com/openshift-service-mesh/istio/pull/880