### PR TITLE
[release-1.27] Disable PILOT_ENABLE_ALPHA_GATEWAY_API in testing via helm

### DIFF
--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -205,7 +205,8 @@ base_cmd=(
   "--istio.test.openshift"
 )
 
-helm_values="global.platform=openshift"
+# disable PILOT_ENABLE_ALPHA_GATEWAY_API env here https://github.com/istio/istio/blob/master/tests/integration/base.yaml#L23 since there is no way how to enable experimental gw api crds on OpenShift
+helm_values="global.platform=openshift,pilot.env.PILOT_ENABLE_ALPHA_GATEWAY_API=false"
 
 # IBM specific modifications
 if [ "${IBM}" == "true" ]; then

--- a/prow/skip_tests/skip_tests_full.yaml
+++ b/prow/skip_tests/skip_tests_full.yaml
@@ -79,6 +79,12 @@ test_suites:
       - name: "TestGatewayConformance/BackendTLSPolicy"
         reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1, should be fixed on OCP 4.22+"
         skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/TLSRouteInvalidReferenceGrant"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']  
+      - name: "TestGatewayConformance/TLSRouteSimpleSameNamespace"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
     skip_subsuites: []
     run_tests_only: []
   security:


### PR DESCRIPTION
Cherry-pick https://github.com/openshift-service-mesh/istio/pull/872 