### PR TITLE
[release-1.26] Disable PILOT_ENABLE_ALPHA_GATEWAY_API in testing via helm

### DIFF
--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -220,12 +220,16 @@ if [ "${TEST_SUITE}" == "pilot" ]; then
     # This flag we need to run the conformance test even if the CRDs are not matching with the desired ones in go.mod
     base_cmd+=("--istio.test.GatewayConformanceAllowCRDsMismatch=true")
     # Stops flaky runs in public clouds
-    base_cmd+=("--istio.test.gatewayConformance.maxTimeToConsistency=180s")
+    base_cmd+=("--istio.test.gatewayConformance.maxTimeToConsistency=300s")
 fi
 
 # If ambient mode executed, add "ambient" profile and args
-if [ "${AMBIENT}" == "true" ]; then
+if [[ "${AMBIENT}" == "true" || "${TEST_SUITE}" == *"ambient"* ]]; then
     base_cmd+=("--istio.test.ambient")
+    # This flag we need to run the conformance test even if the CRDs are not matching with the desired ones in go.mod
+    base_cmd+=("--istio.test.GatewayConformanceAllowCRDsMismatch=true")
+    # Stops flaky runs in public clouds
+    base_cmd+=("--istio.test.gatewayConformance.maxTimeToConsistency=300s")
     helm_values+=",pilot.trustedZtunnelNamespace=${TRUSTED_ZTUNNEL_NAMESPACE}"
 
     # Set local gateway mode for Ambient execution

--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -206,7 +206,8 @@ base_cmd=(
   "--istio.test.openshift"
 )
 
-helm_values="global.platform=openshift"
+# disable PILOT_ENABLE_ALPHA_GATEWAY_API env here https://github.com/istio/istio/blob/master/tests/integration/base.yaml#L23 since there is no way how to enable experimental gw api crds on OpenShift
+helm_values="global.platform=openshift,pilot.env.PILOT_ENABLE_ALPHA_GATEWAY_API=false"
 
 # IBM specific modifications
 if [ "${IBM}" == "true" ]; then

--- a/prow/skip_tests/skip_tests_full.yaml
+++ b/prow/skip_tests/skip_tests_full.yaml
@@ -8,8 +8,11 @@ test_suites:
   pilot:
     skip_tests:
       - name: "TestGatewayConformance"
+        reason: "Needs to be patched to be able to execute. Patch is available on downstream."
+        skip_in: ['midstream_sail']
+      - name: "TestGatewayConformanceAgentgateway"
         reason: ""
-        skip_in: ['midstream_sail','midstream_helm']
+        skip_in: ['midstream_helm']
       - name: "TestGateway/managed-owner"
         reason: ""
         skip_in: ['downstream','midstream_sail','midstream_helm']
@@ -114,7 +117,7 @@ test_suites:
       - name: "TestCNIMisconfigHealsOnRestart"
         reason: ""
         skip_in: ['downstream','midstream_sail','midstream_helm']
-      - name: "TestGatewayConformance"
+      - name: "TestGatewayConformanceAgentgateway"
         reason: ""
         skip_in: ['downstream','midstream_sail','midstream_helm']
       - name: "TestAPIServer"
@@ -138,6 +141,87 @@ test_suites:
       - name: "TestWaypointChanges"
         reason: "The test modifies Istio configuration during the test execution. Sail flow does not support it yet"
         skip_in: ['downstream','midstream_sail']
+      - name: "TestZtunnelSecureMetrics"
+        reason: ""
+        skip_in: ['downstream','midstream_sail']
+      - name: "TestWaypointAsEgressGateway/http_origination_targetPort_with_BackendTLSPolicy"
+        reason: "Disabling because it requires experimental CRDs(#72020)"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestWaypointAsEgressGateway/http_origination_route_with_BackendTLSPolicy"
+        reason: "Disabling because it requires experimental CRDs(#72020)"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestWaypoint/TLS_connection_with_PQC-compliant_settings_should_succeed"
+        reason: "Disabling because it required experimental CRDs"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestWaypoint/TLS_connection_originated_by_the_waypoint_should_succeed"
+        reason: "Disabling because it required experimental CRDs"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestZtunnelCRL"
+        reason: "The new TestZtunnelCRL test still does not have supported values within Sail Operator for the test. Would be enabled, once fixed.(#74391)"
+        skip_in: ['downstream','midstream_sail']
+      - name: "TestGatewayConformance/TLSRouteInvalidReferenceGrant"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/TLSRouteSimpleSameNamespace"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/HTTPRouteCORSAllowCredentialsBehavior"
+        reason: "Not supported on CIO."
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/TLSRouteHostnameIntersection"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/TLSRouteInvalidBackendRefNonexistent"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/TLSRouteInvalidBackendRefUnknownKind"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/TLSRouteInvalidNoMatchingListenerHostname"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/TLSRouteInvalidNoMatchingListener"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/TLSRouteMixedTerminationSameNamespace"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/TLSRouteTerminateSimpleSameNamespace"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/BackendTLSPolicyInvalidCACertificateRef"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/BackendTLSPolicyInvalidKind"
+        reason: "Disabling test which requires experimental CRDs gateway.networking.k8s.io/v1"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/BackendTLSPolicySANValidation"
+        reason: "Disabling test which requires experimental CRDs"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/ListenerSetAllowedNamespaceNone"
+        reason: "ListenerSet CRDs is not installed by default"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/ListenerSetAllowedNamespaceSame"
+        reason: "ListenerSet CRDs is not installed by default"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/ListenerSetAllowedNamespaceSelector"
+        reason: "ListenerSet CRDs is not installed by default"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/ListenerSetAllowedRoutesNamespaces"
+        reason: "ListenerSet CRDs is not installed by default"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/ListenerSetAllowedRoutesSupportedKinds"
+        reason: "ListenerSet CRDs is not installed by default"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/ListenerSetDefaultNotAllowed"
+        reason: "ListenerSet CRDs is not installed by default"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/ListenerSetHTTPRouting"
+        reason: "ListenerSet CRDs is not installed by default"
+        skip_in: ['downstream','midstream_sail','midstream_helm']
+      - name: "TestGatewayConformance/eNamespaceNone"
+        reason: ""
+        skip_in: ['downstream','midstream_sail','midstream_helm']
     skip_subsuites: []
     run_tests_only: []
   telemetry:


### PR DESCRIPTION
Cherry-pick https://github.com/openshift-service-mesh/istio/pull/872 + missing [cherry-pick](https://github.com/openshift-service-mesh/istio/pull/745) from midstream