### PR TITLE
docs: adding specific upstream and Agents documentation for the istio midstream project

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,8 +27,8 @@
 
 **Required PR Label:** Please add one of the following labels to this PR:
 
-- `permanent-change`: For OSSM-specific changes that should be cherry-picked to all release branches
-- `no-permanent-change`: For temporary changes that should NOT be cherry-picked to release branches
-- `pending-upstream-sync`: For changes awaiting upstream synchronization (cherry-pick until synced from upstream)
+- `permanent-change`: For OSSM-specific changes (would not be submitted upstream) — mandatory cherry-pick to all new minor release branches
+- `no-permanent-change`: For changes specific to a release branch that will NOT be cherry-picked to next minor release branches
+- `pending-upstream-sync`: For changes expected to land from Istio upstream — cherry-picked until the commit is synced from upstream
 
 This labeling helps release maintainers identify which changes to include in new release branches.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# Istio Midstream Agent Instructions
+
+This repository is the Red Hat midstream fork of [Istio](https://github.com/istio/istio),
+maintained for OpenShift Service Mesh (OSSM).
+
+## Key Documentation
+
+- **[Upstream Relationship](docs/upstream.md)** -- How this repository relates to
+  upstream Istio, branch mapping, contribution workflow, and sync process.
+
+## Domain Knowledge
+
+The [`.github/.copilot/domain_knowledge/`](.github/.copilot/domain_knowledge/) directory is
+the primary AI knowledge base for this repository. Consult these files before making
+assumptions about internals.
+
+| File | Description |
+|------|-------------|
+| [`integration_test_framework.md`](.github/.copilot/domain_knowledge/integration_test_framework.md) | Integration test framework (`pkg/test/framework`): environment setup, resource management, multi-cluster patterns |
+| [`istio_analysis_messages.md`](.github/.copilot/domain_knowledge/istio_analysis_messages.md) | Istio analyzer messages: what they are, how to access them, and how to add new analyzers |
+| [`istio_tags_and_revisions.md`](.github/.copilot/domain_knowledge/istio_tags_and_revisions.md) | Tags and revisions: role in xDS orchestration, create/update/delete lifecycle |
+| [`istioctl_commands.md`](.github/.copilot/domain_knowledge/istioctl_commands.md) | `istioctl` command structure and configuration sources |
+| [`krt_package.md`](.github/.copilot/domain_knowledge/krt_package.md) | `krt` (Kubernetes Declarative Controller Runtime): declarative controller framework, transformation logic, resource relationships |
+| [`pilot_push_context.md`](.github/.copilot/domain_knowledge/pilot_push_context.md) | Pilot `PushContext`: construction and transformation into xDS messages for Envoy |
+
+## Repository Context
+
+- **Upstream**: https://github.com/istio/istio
+- **Midstream**: https://github.com/openshift-service-mesh/istio
+- Changes in this fork are OSSM-specific patches layered on top of upstream Istio.
+- Prefer landing changes upstream first; only commit OSSM-specific work directly here.
+
+## Development
+
+- Follow the upstream Istio coding conventions and project structure.
+- Keep OSSM-specific patches minimal and clearly marked with JIRA references.
+- PRs are gated by prow CI.
+
+## PR Labels
+
+Every PR to this repository requires one of the following labels (see [CONTRIBUTING.md](CONTRIBUTING.md)):
+
+- **`permanent-change`** — OSSM-specific change that stays permanently in the midstream and must be cherry-picked to new release branches (OpenShift features, customizations, compliance patches).
+- **`no-permanent-change`** — Temporary or experimental change that will be removed or replaced by upstream sync; must NOT be cherry-picked to release branches.
+- **`pending-upstream-sync`** — Change awaiting upstream sync; cherry-pick to release branches only until the equivalent lands from upstream Istio.
+
+Exactly one label is required per PR. The label check CI job enforces this and will fail the PR if missing or if more than one is applied. When generating or reviewing a PR, always determine and apply the correct label before submitting.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,8 @@ assumptions about internals.
 
 ## Repository Context
 
-- **Upstream**: https://github.com/istio/istio
-- **Midstream**: https://github.com/openshift-service-mesh/istio
+- **Upstream**: <https://github.com/istio/istio>
+- **Midstream**: <https://github.com/openshift-service-mesh/istio>
 - Changes in this fork are OSSM-specific patches layered on top of upstream Istio.
 - Prefer landing changes upstream first; only commit OSSM-specific work directly here.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,13 @@
 # Contribution guidelines
 
-So you want to hack on Istio? Yay! Please refer to Istio's overall
+> **This is the Red Hat midstream fork of [istio/istio](https://github.com/istio/istio).**
+> See [docs/upstream.md](docs/upstream.md) for the full upstream contribution workflow,
+> branch mapping, sync process, and guidance on whether a change belongs here or upstream.
+
+So you want to hack on Istio? Please refer to Istio's overall
 [contribution guidelines](https://github.com/istio/community/blob/master/CONTRIBUTING.md)
-to find out how you can help.
+for upstream contribution. For OSSM-specific changes in this midstream repository, follow
+the requirements below.
 
 ## OSSM-Specific Requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,4 +22,9 @@ All pull requests to this repository must include one of the following labels:
 - Are experimental or short-term modifications
 - Will be replaced by upstream synchronization
 
-**Purpose**: These labels help release maintainers identify which changes to include when creating new release branches for OSSM.
+**`pending-upstream-sync`**: Use for changes awaiting upstream synchronization that:
+- Should be cherry-picked to release branches only until the equivalent change is synced from upstream Istio
+- Are backported from upstream but not yet in the midstream sync
+- Will eventually be replaced by the upstream version
+
+**Purpose**: These labels help release maintainers identify which changes to include when creating new release branches for OSSM. Exactly one label must be applied per PR; applying more than one will fail the label check.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,21 +15,17 @@ the requirements below.
 
 All pull requests to this repository must include one of the following labels:
 
-**`permanent-change`**: Use for OSSM-specific changes that:
-- Are added directly to this repository (not synced from upstream)
-- Should be cherry-picked to new release branches
+**`permanent-change`**: Used for OSSM-specific changes (would not be submitted upstream):
+- Mandatory to be cherry-picked to all new minor release branches
+- Permanent in OSSM codebase -> added directly to this repository (not synced from upstream)
 - Include OpenShift-specific features and customizations
-- Will remain permanently in the OSSM codebase
 
-**`no-permanent-change`**: Use for temporary changes that:
-- Will be removed from the repository in the future
-- Should NOT be cherry-picked to release branches
-- Are experimental or short-term modifications
-- Will be replaced by upstream synchronization
+**`no-permanent-change`**: Used for a specific release branch:
+- Used for Automator sync PRs
+- This PR/commit will NOT be cherry-picked to next minor release branches
 
-**`pending-upstream-sync`**: Use for changes awaiting upstream synchronization that:
-- Should be cherry-picked to release branches only until the equivalent change is synced from upstream Istio
-- Are backported from upstream but not yet in the midstream sync
-- Will eventually be replaced by the upstream version
+**`pending-upstream-sync`**: Use for changes expected to land from Istio upstream:
+- PR were merged into supported upstream branches and yet to land into relevant midstream release branches
+- For new release branches: cherry-pick automation checks if the commit already landed (synced) from upstream and if found exclude it from the cherry-pick list proposed for the release maintainer
 
 **Purpose**: These labels help release maintainers identify which changes to include when creating new release branches for OSSM. Exactly one label must be applied per PR; applying more than one will fail the label check.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 > **This is the Red Hat midstream fork of [istio/istio](https://github.com/istio/istio),
 > maintained for [OpenShift Service Mesh (OSSM)](https://www.redhat.com/en/technologies/cloud-computing/openshift/what-is-openshift-service-mesh).**
 >
-> - Upstream repository: https://github.com/istio/istio
-> - Midstream repository: https://github.com/openshift-service-mesh/istio
+> - Upstream repository: <https://github.com/istio/istio>
+> - Midstream repository: <https://github.com/openshift-service-mesh/istio>
 >
 > For details on how this fork relates to upstream, branch mapping, sync process, and
 > contribution workflow, see [docs/upstream.md](docs/upstream.md).
@@ -71,7 +71,7 @@ Istio is composed of these components:
   > simplifies and enhances how microservices in an application talk to each
   > other over the network provided by the underlying platform.
 
-* **Ztunnel** - A lightweight data plane proxy written in Rust,
+- **Ztunnel** - A lightweight data plane proxy written in Rust,
     used in Ambient mesh mode to provide secure connectivity and observability for workloads without sidecar proxies.
 
 - **Istiod** - The Istio control plane. It provides service discovery, configuration and certificate management.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+# Istio — OpenShift Service Mesh Midstream Fork
+
+> **This is the Red Hat midstream fork of [istio/istio](https://github.com/istio/istio),
+> maintained for [OpenShift Service Mesh (OSSM)](https://www.redhat.com/en/technologies/cloud-computing/openshift/what-is-openshift-service-mesh).**
+>
+> - Upstream repository: https://github.com/istio/istio
+> - Midstream repository: https://github.com/openshift-service-mesh/istio
+>
+> For details on how this fork relates to upstream, branch mapping, sync process, and
+> contribution workflow, see [docs/upstream.md](docs/upstream.md).
+> For OSSM-specific contribution requirements (PR labels, coding conventions), see
+> [CONTRIBUTING.md](CONTRIBUTING.md).
+> For AI agent guidance, see [AGENTS.md](AGENTS.md).
+
+---
+
 # Istio
 
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1395/badge)](https://bestpractices.coreinfrastructure.org/projects/1395)

--- a/docs/upstream.md
+++ b/docs/upstream.md
@@ -40,9 +40,9 @@ sail-operator repository's `docs/upstream.md` for the full mapping including OCP
 1. **Prefer upstream first.** Changes that are not OSSM-specific should be proposed as pull
    requests to the upstream Istio repository. Once merged upstream, they will be synced to
    the midstream fork.
-2. **OSSM-specific changes** that have no relevance to the community project (OpenShift CI
+1. **OSSM-specific changes** that have no relevance to the community project (OpenShift CI
    configs, FIPS patches, OSSM-only features) go directly to the midstream repository.
-3. Bug fixes that affect both upstream and midstream should land upstream first to avoid
+1. Bug fixes that affect both upstream and midstream should land upstream first to avoid
    divergence.
 
 ## Sync Process

--- a/docs/upstream.md
+++ b/docs/upstream.md
@@ -1,0 +1,140 @@
+# Upstream Relationship
+
+## Overview
+
+This repository is the Red Hat midstream fork of [Istio](https://github.com/istio/istio).
+It is maintained at
+[openshift-service-mesh/istio](https://github.com/openshift-service-mesh/istio) and carries
+OpenShift Service Mesh (OSSM) specific patches on top of the upstream Istio codebase.
+
+The midstream fork tracks upstream Istio release branches and adds changes required for
+OpenShift integration, FIPS compliance, OSSM-specific bug fixes, and CI configuration.
+
+## Repository Structure
+
+| Role       | URL                                                     |
+|------------|---------------------------------------------------------|
+| Upstream   | https://github.com/istio/istio                          |
+| Midstream  | https://github.com/openshift-service-mesh/istio         |
+
+## Branch Mapping
+
+Each midstream branch tracks the same-named upstream branch.
+
+| Midstream Branch  | Upstream Branch  | OSSM Release |
+|-------------------|------------------|--------------|
+| `master`          | `master`         | (next)       |
+| `release-1.24`    | `release-1.24`   | OSSM 3.0     |
+| `release-1.26`    | `release-1.26`   | OSSM 3.1     |
+| `release-1.27`    | `release-1.27`   | OSSM 3.2     |
+| `release-1.28`    | `release-1.28`   | OSSM 3.3     |
+| `release-1.30`    | `release-1.30`   | OSSM 3.4     |
+| `release-1.31`    | `release-1.31`   | OSSM 3.5     |
+
+The [sail-operator midstream](https://github.com/openshift-service-mesh/sail-operator)
+repository maps its own release branches to specific istio midstream branches. See the
+sail-operator repository's `docs/upstream.md` for the full mapping including OCP versions.
+
+## Contribution Workflow
+
+1. **Prefer upstream first.** Changes that are not OSSM-specific should be proposed as pull
+   requests to the upstream Istio repository. Once merged upstream, they will be synced to
+   the midstream fork.
+2. **OSSM-specific changes** that have no relevance to the community project (OpenShift CI
+   configs, FIPS patches, OSSM-only features) go directly to the midstream repository.
+3. Bug fixes that affect both upstream and midstream should land upstream first to avoid
+   divergence.
+
+## Sync Process
+
+Upstream changes are brought into midstream through periodic merges and targeted cherry-picks.
+
+- An automator bot performs routine merges from upstream branches into the corresponding
+  midstream branches.
+- When the bot merge produces conflicts or when specific commits need to be pulled ahead of
+  a full merge, maintainers perform manual cherry-picks.
+- After a sync, CI (prow) runs on the midstream branch to validate that OSSM-specific patches
+  still apply cleanly and tests pass.
+
+## Coding Conventions
+
+- Follow the coding style and conventions established by the upstream Istio project.
+- OSSM-specific patches should be kept as small and isolated as possible.
+- Do not modify upstream files unnecessarily; prefer additive changes or configuration-based
+  customization.
+
+### Labeling permanent OSSM changes
+
+Changes that are intentional, permanent divergences from upstream (not cherry-pick candidates)
+must be labeled so they survive future merges without confusion. Use this comment style:
+
+```go
+// OSSM-only: <JIRA-KEY> <short reason>
+```
+
+Example:
+
+```go
+// OSSM-only: OSSM-12345 FIPS compliance requires non-upstream TLS settings
+```
+
+Apply the label on the same line (or the line above for blocks) as the divergent code.
+This makes it easy to locate all permanent patches with `git grep "OSSM-only"` and avoids
+re-introducing upstream behavior by accident during a merge conflict resolution.
+
+Changes that are intended for upstream contribution but have not landed yet should instead
+reference the upstream issue or PR in the commit message, not in a code comment.
+
+## CI Configuration
+
+Prow CI job definitions for the istio midstream are located in the
+[openshift/release](https://github.com/openshift/release) repository:
+
+- [ci-operator/config/openshift-service-mesh/istio/](https://github.com/openshift/release/tree/main/ci-operator/config/openshift-service-mesh/istio)
+
+Each file corresponds to a tracked branch:
+
+| Config file                                       | Branch         | Sync job                        | Schedule              |
+|---------------------------------------------------|----------------|---------------------------------|-----------------------|
+| `openshift-service-mesh-istio-master.yaml`        | `master`       | `sync-upstream-istio-master`    | Periodic, weekdays 05:00 UTC |
+| `openshift-service-mesh-istio-release-1.24.yaml`  | `release-1.24` | manual cherry-picks only        | —                     |
+| `openshift-service-mesh-istio-release-1.26.yaml`  | `release-1.26` | manual cherry-picks only        | —                     |
+| `openshift-service-mesh-istio-release-1.27.yaml`  | `release-1.27` | manual cherry-picks only        | —                     |
+| `openshift-service-mesh-istio-release-1.28.yaml`  | `release-1.28` | manual cherry-picks only        | —                     |
+| `openshift-service-mesh-istio-release-1.30.yaml`  | `release-1.30` | manual cherry-picks only        | —                     |
+
+**`master` sync**: the `sync-upstream-istio-master` periodic job runs `automator-main.sh` to
+open a merge PR from `upstream/istio@master` into `midstream/master` on a weekday schedule.
+It applies the `tide/merge-method-merge` and `auto-merge` labels so the PR merges automatically
+once CI passes.
+
+**Release branches**: there is no automated upstream-to-midstream sync. Fixes are brought in
+via manual cherry-picks. Each release branch config does include an `update-istio-module`
+postsubmit that, after any push, opens a PR in the `sail-operator` midstream repository to
+bump its `go.mod` dependency pin to the new commit.
+
+## PR Process
+
+| Target             | Where to open the PR                                    |
+|--------------------|---------------------------------------------------------|
+| Community feature  | https://github.com/istio/istio                          |
+| OSSM-only change   | https://github.com/openshift-service-mesh/istio         |
+
+- All PRs are gated by CI (prow). Ensure the relevant tests pass before submitting.
+- Reference the relevant JIRA issue in the PR description.
+
+### Required PR labels
+
+All pull requests to the midstream repository must carry exactly one of these labels
+(defined in [CONTRIBUTING.md](../CONTRIBUTING.md)):
+
+| Label | When to use |
+|-------|-------------|
+| `permanent-change` | OSSM-specific change that lives permanently in the midstream: OpenShift features, customizations, compliance patches; must be cherry-picked to every new release branch |
+| `no-permanent-change` | Temporary or experimental change that will be removed or replaced by upstream sync; must NOT be cherry-picked to release branches |
+| `pending-upstream-sync` | Change awaiting upstream sync; cherry-pick to release branches only until the equivalent lands from upstream Istio |
+
+Exactly one label must be applied per PR — the label check CI job enforces this and will
+fail the PR if the label is missing or more than one is set. Automated Automator PRs are
+exempt from the check. Labels are used by release maintainers to decide which commits to
+carry forward when branching a new OSSM release.


### PR DESCRIPTION
**Please provide a description of this PR:**
Adding specific documentation for Agents and upstream to midstream relation. It includes all the information to point to the knowledge AI information already created upstream

Note: adding cherry pick to have the AI information while working on any branch

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

**Required PR Label:** Please add one of the following labels to this PR:

- `permanent-change`: For OSSM-specific changes that should be cherry-picked to all release branches
- `no-permanent-change`: For temporary changes that should NOT be cherry-picked to release branches
- `pending-upstream-sync`: For changes awaiting upstream synchronization (cherry-pick until synced from upstream)

This labeling helps release maintainers identify which changes to include in new release branches.
