### PR TITLE
[release-1.24] prow: skip internal registry setup when HUB targets quay.io

### DIFF
--- a/prow/setup/ocp_setup.sh
+++ b/prow/setup/ocp_setup.sh
@@ -33,7 +33,16 @@ TIMEOUT=300
 export NAMESPACE="${NAMESPACE:-"istio-system"}"
 
 function setup_internal_registry() {
-  # Validate that the internal registry is running in the OCP Cluster, configure the variable to be used in the make target. 
+  # If HUB is already set to a Quay registry (by the images-build CI step), skip
+  # internal registry setup so the pre-pushed images are not overwritten.
+  # Only skip for quay.io targets — other defaults (e.g. mirror.gcr.io/istio) must
+  # still be overwritten by the OCP internal registry route URL.
+  if [[ "${HUB:-}" == quay.io/* ]]; then
+    echo "HUB is already set to '${HUB}' (Quay registry), skipping internal registry setup."
+    return 0
+  fi
+
+  # Validate that the internal registry is running in the OCP Cluster, configure the variable to be used in the make target.
   # If there is no internal registry, the test can't be executed targeting to the internal registry
 
   # Check if the registry pods are running


### PR DESCRIPTION
setup_internal_registry() was overriding HUB to the internal OpenShift image registry, whose TLS certificate is signed by the cluster's ingress CA. docker buildx bake does not trust this CA, causing pushes to fail with "x509: certificate signed by unknown authority".

Backport the quay.io early-return guard from release-1.26 (572917aaf2) so that when the CI step already sets HUB=quay.io/sail-dev, the internal registry setup is skipped and images are pushed to quay.io instead.
