### PR TITLE
[release-1.24] additional cherry-picks

### DIFF
--- a/prow/check-cluster-ready.sh
+++ b/prow/check-cluster-ready.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Copyright 2019 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Validates that all OpenShift cluster operators are stable before running tests.
+#
+# When kube-apiserver is rolling, it terminates oc exec WebSocket sessions. Running
+# this check *before* any oc exec call prevents those mid-session drops from being
+# mistaken for test failures.
+#
+# Usage:
+#   Standalone:  ./prow/check-cluster-ready.sh
+#   Sourced:     source ./prow/check-cluster-ready.sh   # provides check_cluster_operators()
+#
+# Environment:
+#   CLUSTER_OPERATOR_TIMEOUT  seconds to wait before giving up (default: 600)
+
+check_cluster_operators() {
+  if ! command -v jq &> /dev/null; then
+    echo "ERROR: jq is required for the cluster operator health check. Please install jq." >&2
+    return 1
+  fi
+
+  local timeout_seconds=${CLUSTER_OPERATOR_TIMEOUT:-2700}
+  local end_time=$(( $(date +%s) + timeout_seconds ))
+  echo "Validating OpenShift cluster operators are stable (timeout: ${timeout_seconds}s)..."
+
+  while [ "$(date +%s)" -lt "$end_time" ]; do
+    local oc_output unstable_operators
+    if ! oc_output=$(oc get clusteroperator -o json 2>&1); then
+      echo "WARNING: 'oc get clusteroperator' failed (transient error?): ${oc_output}" >&2
+      sleep 15
+      continue
+    fi
+
+    if ! unstable_operators=$(jq '[.items[] | select(.status.conditions[] | (.type == "Available" and .status == "False") or (.type == "Progressing" and .status == "True") or (.type == "Degraded" and .status == "True"))] | length' <<< "${oc_output}"); then
+      echo "WARNING: jq failed to parse clusteroperator output" >&2
+      sleep 15
+      continue
+    fi
+
+    if [[ $unstable_operators -eq 0 ]]; then
+      echo "All cluster operators are stable."
+      return 0
+    fi
+
+    echo "WARNING: ${unstable_operators} unstable operator(s):" >&2
+    jq -r '.items[] | select(.status.conditions[] | (.type == "Available" and .status == "False") or (.type == "Progressing" and .status == "True") or (.type == "Degraded" and .status == "True")) | .metadata.name as $name | .status.conditions[] | select((.type == "Available" and .status == "False") or (.type == "Progressing" and .status == "True") or (.type == "Degraded" and .status == "True")) | "  \($name): \(.type)=\(.status) — \(.message)"' <<< "${oc_output}" >&2
+    sleep 15
+  done
+
+  echo "ERROR: Timeout reached. Not all cluster operators are stable." >&2
+  oc get clusteroperator >&2 || true
+  return 1
+}
+
+# When executed directly (not sourced), run the check and exit with its status.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  check_cluster_operators
+fi

--- a/prow/integ-suite-ocp.sh
+++ b/prow/integ-suite-ocp.sh
@@ -45,6 +45,9 @@ set -u
 # Print commands
 set -x
 
+# shellcheck source=prow/check-cluster-ready.sh
+source "${ROOT}/prow/check-cluster-ready.sh"
+
 # shellcheck source=common/scripts/kind_provisioner.sh
 source "${ROOT}/prow/setup/ocp_setup.sh"
 
@@ -61,19 +64,22 @@ build_images() {
     # use ubuntu:noble to test vms by default
     nonDistrolessTargets="docker.app docker.app_sidecar_ubuntu_noble docker.ext-authz docker.ztunnel "
 
-    if [[ "${VARIANT:-default}" == "distroless" ]]; then
-        echo "Building distroless images"
+    if [[ -z "${VARIANT:-}" || "${VARIANT}" == "distroless" ]]; then
+        echo "Building default and distroless images"
+        DOCKER_ARCHITECTURES="${arch}" DOCKER_BUILD_VARIANTS="default" DOCKER_TARGETS="${targets} ${nonDistrolessTargets}" make dockerx.pushx
         DOCKER_ARCHITECTURES="${arch}" DOCKER_BUILD_VARIANTS="distroless" DOCKER_TARGETS="${targets}" make dockerx.pushx
-        DOCKER_ARCHITECTURES="${arch}" DOCKER_BUILD_VARIANTS="default" DOCKER_TARGETS="${nonDistrolessTargets}" make dockerx.pushx
     else
         echo "Building default images"
-        DOCKER_ARCHITECTURES="${arch}"  DOCKER_BUILD_VARIANTS="${VARIANT:-default}" DOCKER_TARGETS="${targets} ${nonDistrolessTargets}" make dockerx.pushx
+        DOCKER_ARCHITECTURES="${arch}" DOCKER_BUILD_VARIANTS="${VARIANT}" DOCKER_TARGETS="${targets} ${nonDistrolessTargets}" make dockerx.pushx
     fi
 }
 
 # Define the artifacts directory
 ARTIFACTS_DIR="${ARTIFACT_DIR:-"${WD}/artifacts"}"
 JUNIT_REPORT_DIR="${ARTIFACTS_DIR}/junit"
+# Create the junit output directory unconditionally so it is available even when
+# SKIP_SETUP=true (images pre-built by the servicemesh-istio-images-build CI step).
+mkdir -p "${JUNIT_REPORT_DIR}"
 
 # Install MetalLB if the flag is set
 if [ "${INSTALL_METALLB}" == "true" ]; then
@@ -83,9 +89,6 @@ if [ "${INSTALL_METALLB}" == "true" ]; then
 # Run the setup only if MetalLB is not being installed and setup is not skipped
 elif [ "${INSTALL_METALLB}" != "true" ] && [ "${SKIP_SETUP}" != "true" ]; then
     echo "Running full setup..."
-
-    # Ensure artifacts directory exists
-    mkdir -p "${JUNIT_REPORT_DIR}"
 
     # Setup the internal registry for the OCP cluster
     setup_internal_registry
@@ -108,8 +111,12 @@ fi
 # Run the integration tests
 echo "Running integration tests"
 
-# Set the HUB to the internal registry svc URL to avoid the need to authenticate to pull images
-HUB="image-registry.openshift-image-registry.svc:5000/${NAMESPACE}"
+# Set the HUB to the internal registry svc URL to avoid the need to authenticate
+# to pull images. Skip if HUB already targets quay.io (images were pre-pushed by
+# the servicemesh-istio-images-build CI step).
+if [[ "${HUB:-}" != quay.io/* ]]; then
+    HUB="image-registry.openshift-image-registry.svc:5000/${NAMESPACE}"
+fi
 
 # Check OCP version
 if ! OCP_VERSION_FULL=$(oc get clusterversion version -o jsonpath='{.status.desired.version}' 2>/dev/null); then
@@ -152,7 +159,7 @@ base_cmd=("go" "test" "-p" "1" "-v" "-count=1" "-tags=integ" "-vet=off" "-timeou
           "--istio.test.work_dir=${ARTIFACTS_DIR}"
           "--istio.test.skipTProxy=true"
           "--istio.test.skipVM=true"
-          "--istio.test.kube.helm.values=global.platform=openshift"
+          "--istio.test.kube.helm.values=global.platform=openshift,pilot.env.PILOT_ENABLE_ALPHA_GATEWAY_API=false"
           "--istio.test.istio.enableCNI=true"
           "--istio.test.hub=${HUB}"
           "--istio.test.tag=${TAG}"
@@ -163,6 +170,10 @@ base_cmd=("go" "test" "-p" "1" "-v" "-count=1" "-tags=integ" "-vet=off" "-timeou
 if [ -n "${SKIP_TESTS}" ]; then
     base_cmd+=("-skip" "${SKIP_TESTS}")
 fi
+
+# Re-check cluster operators after setup: the kube-apiserver can start rolling
+# again during image build/push, dropping the websocket when go test starts.
+check_cluster_operators
 
 # Execute the command and handle junit output
 if [ "${TEST_OUTPUT_FORMAT}" == "junit" ]; then

--- a/prow/setup/ocp_setup.sh
+++ b/prow/setup/ocp_setup.sh
@@ -33,7 +33,16 @@ TIMEOUT=300
 export NAMESPACE="${NAMESPACE:-"istio-system"}"
 
 function setup_internal_registry() {
-  # Validate that the internal registry is running in the OCP Cluster, configure the variable to be used in the make target. 
+  # If HUB is already set to a Quay registry (by the images-build CI step), skip
+  # internal registry setup so the pre-pushed images are not overwritten.
+  # Only skip for quay.io targets — other defaults (e.g. mirror.gcr.io/istio) must
+  # still be overwritten by the OCP internal registry route URL.
+  if [[ "${HUB:-}" == quay.io/* ]]; then
+    echo "HUB is already set to '${HUB}' (Quay registry), skipping internal registry setup."
+    return 0
+  fi
+
+  # Validate that the internal registry is running in the OCP Cluster, configure the variable to be used in the make target.
   # If there is no internal registry, the test can't be executed targeting to the internal registry
 
   # Check if the registry pods are running
@@ -114,6 +123,15 @@ items:
 
 # Deploy MetalLB in the OCP cluster and configure IP address pool
 function deployMetalLB() {
+  # Check if MetalLB is already deployed
+  echo "Checking if MetalLB is already deployed..."
+  if oc get metallb metallb -n metallb-system && oc get ipaddresspool default -n metallb-system &> /dev/null; then
+    echo "MetalLB is already deployed (MetalLB CR and IPAddressPool CR exist), skipping..."
+    return 0
+  else
+    echo "MetalLB CR or IPAddressPool CR is not deployed, deploying..."
+  fi
+
   # Create the metallb-system namespace
   echo '
 apiVersion: v1
@@ -132,7 +150,8 @@ spec:
   channel: stable
   name: metallb-operator
   source: redhat-operators
-  sourceNamespace: openshift-marketplace' | oc apply -f -
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic' | oc apply -f -
 
   # Check operator Phase is Succeeded
   # shellcheck disable=SC2016
@@ -147,7 +166,7 @@ metadata:
   namespace: metallb-system' | oc apply -f -
 
   # Check MetalLB controller is running
-timeout --foreground -v -s SIGHUP -k ${TIMEOUT} ${TIMEOUT} bash -c 'until oc get pods -n metallb-system --no-headers | grep controller | grep "Running"; do sleep 5; done && echo "The MetalLB controller is running."'
+  timeout --foreground -v -s SIGHUP -k ${TIMEOUT} ${TIMEOUT} bash -c "until oc get pods -n metallb-system --no-headers | grep controller | grep 'Running'; do sleep 5; done && echo 'The MetalLB controller is running.'"
 
   # Get Nodes Internal IP by using: kubectl get nodes -l node-role.kubernetes.io/worker -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}'
   NODE_IPS=$(oc get nodes -l node-role.kubernetes.io/worker -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}' | tr ' ' ',')


### PR DESCRIPTION
Backport required fixes from release-1.26:

- Guard HUB override so quay.io images (pre-pushed by images-build step)
  are not overwritten by the internal OCP registry URL.

- Add quay.io early-return in setup_internal_registry() to skip
  internal registry setup when images already target quay.io.

- Backport check-cluster-ready.sh to validate cluster operators are
  stable before running tests.

- Move mkdir for junit report dir before the setup block so it is
  available when SKIP_SETUP=true.

- Fix build_images() to build both default and distroless variants
  when VARIANT is unset.

- Disable PILOT_ENABLE_ALPHA_GATEWAY_API via helm values override.
  base.yaml enables it by default but OpenShift does not support
  experimental gateway API CRDs.

- Add MetalLB idempotency check to skip deployment when already present.

- Add installPlanApproval: Automatic to MetalLB subscription.

- Fix MetalLB controller readiness check quoting.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>