### PR TITLE
[tmp, do not merge] Fix flaky integration tests: ExternalName alias, HTTP/2 gateway, JWT claim route

### DIFF
--- a/pilot/pkg/networking/core/route/route.go
+++ b/pilot/pkg/networking/core/route/route.go
@@ -259,7 +259,13 @@ func buildSidecarVirtualHostsForVirtualService(
 		Mesh:                      push.Mesh,
 		Push:                      push,
 		LookupService: func(name host.Name) *model.Service {
-			return serviceRegistry[name]
+			if svc, ok := serviceRegistry[name]; ok {
+				return svc
+			}
+			// Fallback to unfiltered lookup for alias resolution: serviceRegistry is port-filtered,
+			// but a VirtualService destination may reference an ExternalName service that doesn't
+			// declare the listener port.
+			return push.ServiceForHostname(node, name)
 		},
 		LookupDestinationCluster: GetDestinationCluster,
 		LookupHash: func(destination *networking.HTTPRouteDestination) *networking.LoadBalancerSettings_ConsistentHashLB {

--- a/pilot/pkg/networking/core/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/sidecar_simulation_test.go
@@ -1294,6 +1294,97 @@ spec:
 			},
 		},
 	})
+
+	// VirtualService with alias as destination on a port the alias doesn't declare.
+	// This is the scenario that exercises the LookupService fallback added in the fix:
+	// alias (port 80 only) is absent from the port-81-filtered servicesByName map, so
+	// without the fallback GetDestinationCluster never sees the ExternalName field and
+	// produces the wrong cluster name: outbound|80||alias... (non-existent → 503).
+	// With the fallback, the unfiltered scope lookup finds alias, the ExternalName
+	// redirect fires, and the cluster resolves to outbound|80||concrete... (valid).
+	appAndPartialAlias := `apiVersion: v1
+kind: Service
+metadata:
+  name: alias
+  namespace: default
+spec:
+  type: ExternalName
+  externalName: concrete.default.svc.cluster.local
+  ports:
+  - name: http
+    port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: concrete
+  namespace: default
+spec:
+  clusterIP: 1.2.3.4
+  ports:` + ports + `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app
+  namespace: default
+spec:
+  clusterIP: 1.2.3.5
+  ports:
+  - name: http
+    port: 80
+  - name: auto
+    port: 81`
+	runSimulationTest(t, nil, xds.FakeOptions{}, simulationTest{
+		config: `apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: route-via-alias
+  namespace: default
+spec:
+  hosts:
+  - app.default.svc.cluster.local
+  http:
+  - route:
+    - destination:
+        host: alias.default.svc.cluster.local
+        port:
+          number: 80`,
+		kubeConfig: appAndPartialAlias,
+		calls: []simulation.Expect{
+			{
+				// alias declares port 80 only. The call arrives on port 81, so alias is
+				// absent from the port-filtered servicesByName map used to build the
+				// port-81 route config. The LookupService fallback must find alias via
+				// the unfiltered scope and trigger the ExternalName redirect so that the
+				// cluster resolves to concrete, not to the non-existent alias cluster.
+				Name: "VS destination is ExternalName alias missing listener port; ExternalName redirect must fire via fallback",
+				Call: simulation.Call{
+					Address:    "1.2.3.5",
+					Port:       81,
+					Protocol:   simulation.HTTP,
+					HostHeader: "app.default.svc.cluster.local",
+				},
+				Result: simulation.Result{
+					ClusterMatched: "outbound|80||concrete.default.svc.cluster.local",
+				},
+			},
+			{
+				// Baseline: alias declares port 80, so it IS in the port-filtered map.
+				// The ExternalName redirect fires on the standard path without the fallback.
+				Name: "VS destination is ExternalName alias on declared port; ExternalName redirect fires normally",
+				Call: simulation.Call{
+					Address:    "1.2.3.5",
+					Port:       80,
+					Protocol:   simulation.HTTP,
+					HostHeader: "app.default.svc.cluster.local",
+				},
+				Result: simulation.Result{
+					ClusterMatched: "outbound|80||concrete.default.svc.cluster.local",
+				},
+			},
+		},
+	})
 }
 
 func TestPassthroughTraffic(t *testing.T) {

--- a/releasenotes/notes/externalname-alias-port-filtered.yaml
+++ b/releasenotes/notes/externalname-alias-port-filtered.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** ExternalName alias resolution failing with `cluster_not_found` when the alias service
+    does not declare the listener port. `LookupService` now falls back to an unfiltered lookup
+    via `PushContext.ServiceForHostname` when the port-filtered service registry misses the alias.

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -2182,9 +2182,13 @@ spec:
 					HTTP: echo.HTTP{
 						HTTP2: h2,
 					},
-					Count: 1,
+					Count:   1,
+					Timeout: 15 * time.Second,
 					Port: echo.Port{
 						Protocol: protocol.HTTP,
+					},
+					Retry: echo.Retry{
+						Options: []retry.Option{retry.Timeout(60 * time.Second)},
 					},
 					Check: check.And(
 						check.OK(),

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"fmt"
+	"time"
 
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework"
@@ -29,6 +30,8 @@ import (
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/istio/ingress"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/tmpl"
 	"istio.io/istio/pkg/test/util/yml"
 )
@@ -265,6 +268,17 @@ func skipAmbient(t framework.TestContext, reason string) skip {
 }
 
 func RunAllTrafficTests(t framework.TestContext, i istio.Instance, apps deployment.SingleNamespaceView) {
+	retry.UntilSuccessOrFail(t, func() error {
+		ingr := i.IngressFor(t.Clusters().Default())
+		addrs, _ := ingr.HTTPAddresses()
+		if len(addrs) == 0 {
+			scopes.Framework.Infof("ingress gateway address not ready, retrying...")
+			return fmt.Errorf("ingress gateway address not available yet")
+		}
+		scopes.Framework.Infof("ingress gateway address resolved: %v", addrs)
+		return nil
+	}, retry.Timeout(5*time.Minute), retry.BackoffDelay(15*time.Second))
+
 	RunCase := func(name string, f func(t TrafficContext)) {
 		t.NewSubTest(name).Run(func(t framework.TestContext) {
 			f(TrafficContext{TestContext: t, Apps: apps, Istio: i})


### PR DESCRIPTION
## Summary
- **ExternalName alias resolution**: fix `503 cluster_not_found` for VirtualService destinations referencing an ExternalName service that doesn't declare the listener port. Adds a fallback to unfiltered service lookup in `LookupService` so the ExternalName redirect fires correctly.
- **HTTP/2 gateway client_protocol flakiness**: AWS ELB delays forwarding traffic to the ingress gateway for 15-30s after config changes (Gateway+VirtualService+DestinationRule apply). During this window, requests hang at the ELB and time out. With the default 5s per-request timeout and 30s retry budget (converge=3), the test has no chance. Fix: increase the per-request timeout to 15s and the total retry timeout to 60s, giving enough headroom for config propagation + 3 consecutive successes.
- **JWT claim route DNS flakiness**: pre-warm ingress gateway DNS at the top of `RunAllTrafficTests` to absorb AWS ELB DNS propagation delay (~4 min) that exceeded the 3-minute `getAddressTimeout`, failing the first `viaIngress` test.

## Test plan
- [ ] `TestTraffic/externalname/routed/auto-http` no longer flakes with 503
- [ ] `TestTraffic/gateway/client_protocol_-_http2_use_client_with_*` no longer times out
- [ ] `TestTraffic/gateway/client_protocol_-_http1_use_client_with_*` no longer times out
- [ ] `TestTraffic/jwt-claim-route/matched_with_nested_claim_using_claim_to_header:200` no longer fails with `failed to get host and port`
- [ ] Unit test `TestExternalNameServiceLookupFallback` (sidecar_simulation_test.go) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)